### PR TITLE
chore: change api folder location

### DIFF
--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api\Auth;
+namespace App\Http\Controllers\Api\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Traits\ApiResponses;

--- a/app/Http/Controllers/Api/HealthController.php
+++ b/app/Http/Controllers/Api/HealthController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Traits\ApiResponses;

--- a/app/Http/Controllers/Api/Journals/JournalController.php
+++ b/app/Http/Controllers/Api/Journals/JournalController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api\Journals;
+namespace App\Http\Controllers\Api\Journals;
 
 use App\Actions\CreateJournal;
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Api/Settings/Profile/LogController.php
+++ b/app/Http/Controllers/Api/Settings/Profile/LogController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api\Settings\Profile;
+namespace App\Http\Controllers\Api\Settings\Profile;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\LogResource;

--- a/app/Http/Controllers/Api/Settings/Profile/ProfileController.php
+++ b/app/Http/Controllers/Api/Settings/Profile/ProfileController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api\Settings\Profile;
+namespace App\Http\Controllers\Api\Settings\Profile;
 
 use App\Http\Controllers\Controller;
 use App\Actions\UpdateUserInformation;

--- a/app/Http/Controllers/Api/Settings/Security/ApiKeyController.php
+++ b/app/Http/Controllers/Api/Settings/Security/ApiKeyController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers\App\Api\Settings\Security;
+namespace App\Http\Controllers\Api\Settings\Security;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ApiResource;

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\App\Api\Auth\LoginController;
-use App\Http\Controllers\App\Api\HealthController;
-use App\Http\Controllers\App\Api\Settings;
-use App\Http\Controllers\App\Api\Journals;
+use App\Http\Controllers\Api\Auth\LoginController;
+use App\Http\Controllers\Api\HealthController;
+use App\Http\Controllers\Api\Settings;
+use App\Http\Controllers\Api\Journals;
 use Illuminate\Support\Facades\Route;
 
 Route::name('api.')->group(function (): void {

--- a/tests/Feature/Controllers/Api/Auth/LoginControllerTest.php
+++ b/tests/Feature/Controllers/Api/Auth/LoginControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api\Auth;
+namespace Tests\Feature\Controllers\Api\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Controllers/Api/HealthControllerTest.php
+++ b/tests/Feature/Controllers/Api/HealthControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api;
+namespace Tests\Feature\Controllers\Api;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;

--- a/tests/Feature/Controllers/Api/Journals/JournalControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api\Journals;
+namespace Tests\Feature\Controllers\Api\Journals;
 
 use App\Models\Journal;
 use App\Models\User;

--- a/tests/Feature/Controllers/Api/Settings/Profile/LogControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Profile/LogControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api\Settings\Profile;
+namespace Tests\Feature\Controllers\Api\Settings\Profile;
 
 use App\Models\Log;
 use App\Models\User;

--- a/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api\Settings\Profile;
+namespace Tests\Feature\Controllers\Api\Settings\Profile;
 
 use App\Models\User;
 use Carbon\Carbon;

--- a/tests/Feature/Controllers/Api/Settings/Security/ApiKeyControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Security/ApiKeyControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Controllers\App\Api\Settings\Security;
+namespace Tests\Feature\Controllers\Api\Settings\Security;
 
 use App\Models\User;
 use Carbon\Carbon;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reorganized API folder structure by removing redundant nesting level
- Updated all API controller namespaces from `App\Http\Controllers\App\Api\*` to `App\Http\Controllers\Api\*`
- Updated all API test namespaces from `Tests\Feature\Controllers\App\Api\*` to `Tests\Feature\Controllers\Api\*`
- Updated route imports in `routes/api.php` to reference controllers from new namespace structure
- Affected controllers: LoginController, HealthController, JournalController, ProfileController, LogController, ApiKeyController
- No functional or logic changes; purely a structural reorganization for cleaner directory hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->