### PR TITLE
feat: add user time format

### DIFF
--- a/app/Actions/UpdateUserInformation.php
+++ b/app/Actions/UpdateUserInformation.php
@@ -18,6 +18,7 @@ final readonly class UpdateUserInformation
         private string $lastName,
         private ?string $nickname,
         private string $locale,
+        private bool $timeFormat24h,
     ) {}
 
     /**
@@ -52,6 +53,7 @@ final readonly class UpdateUserInformation
             'email' => $this->email,
             'nickname' => $this->nickname,
             'locale' => $this->locale,
+            'time_format_24h' => $this->timeFormat24h,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Settings/Profile/ProfileController.php
+++ b/app/Http/Controllers/Api/Settings/Profile/ProfileController.php
@@ -36,6 +36,7 @@ final class ProfileController extends Controller
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique(User::class)->ignore(Auth::user()->id)],
             'nickname' => ['nullable', 'string', 'max:255'],
             'locale' => ['required', 'string', 'max:255'],
+            'time_format_24h' => ['required', 'boolean'],
         ]);
 
         new UpdateUserInformation(
@@ -45,6 +46,7 @@ final class ProfileController extends Controller
             lastName: $validated['last_name'],
             nickname: $validated['nickname'] ?? null,
             locale: $validated['locale'],
+            timeFormat24h: $validated['time_format_24h'],
         )->execute();
 
         return new UserResource(Auth::user()->refresh());

--- a/app/Http/Controllers/App/Settings/ProfileController.php
+++ b/app/Http/Controllers/App/Settings/ProfileController.php
@@ -43,6 +43,7 @@ final class ProfileController extends Controller
                 Rule::unique(User::class)->ignore(Auth::user()->id),
             ],
             'locale' => ['required', 'string', Rule::in(['en', 'fr'])],
+            'time_format_24h' => ['required', Rule::in(['true', 'false'])],
         ]);
 
         new UpdateUserInformation(
@@ -52,6 +53,7 @@ final class ProfileController extends Controller
             lastName: $validated['last_name'],
             nickname: $validated['nickname'],
             locale: $validated['locale'],
+            timeFormat24h: $validated['time_format_24h'] === 'true' ? true : false,
         )->execute();
 
         return to_route('settings.profile.index')

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -29,6 +29,7 @@ final class UserResource extends JsonResource
                 'nickname' => $this->nickname,
                 'email' => $this->email,
                 'locale' => $this->locale,
+                'time_format_24h' => $this->time_format_24h,
                 'created_at' => $this->created_at->timestamp,
                 'updated_at' => $this->updated_at->timestamp,
             ],

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $first_name
  * @property string $last_name
  * @property string $nickname
+ * @property bool $time_format_24h
  * @property string $email
  * @property Carbon|null $email_verified_at
  * @property string|null $two_factor_secret
@@ -57,6 +58,7 @@ final class User extends Authenticatable implements MustVerifyEmail
         'first_name',
         'last_name',
         'nickname',
+        'time_format_24h',
         'email',
         'password',
         'locale',
@@ -97,6 +99,7 @@ final class User extends Authenticatable implements MustVerifyEmail
             'first_name' => 'encrypted',
             'last_name' => 'encrypted',
             'nickname' => 'encrypted',
+            'time_format_24h' => 'boolean',
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'two_factor_confirmed_at' => 'datetime',

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -44,6 +44,7 @@ final class UserFactory extends Factory
             'is_guest' => false,
             'guest_token' => null,
             'guest_expires_at' => null,
+            'time_format_24h' => true,
         ];
     }
 

--- a/database/migrations/2025_06_21_215155_create_users_table.php
+++ b/database/migrations/2025_06_21_215155_create_users_table.php
@@ -18,6 +18,7 @@ return new class extends Migration {
             $table->text('first_name');
             $table->text('last_name');
             $table->text('nickname')->nullable();
+            $table->boolean('time_format_24h')->default(true);
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->text('two_factor_secret')->nullable();

--- a/docs/bruno/JournalOS/Account management/Profile/Update my information.bru
+++ b/docs/bruno/JournalOS/Account management/Profile/Update my information.bru
@@ -17,6 +17,7 @@ body:json {
     "email": "admin@admin.coms",
     "nickname": "Dwightchou",
     "born_at": "1985-03-15",
-    "locale": "fr"
+    "locale": "fr",
+    "time_format_24h": false
   }
 }

--- a/docs/bruno/JournalOS/collection.bru
+++ b/docs/bruno/JournalOS/collection.bru
@@ -7,5 +7,5 @@ auth {
 }
 
 auth:bearer {
-  token: 1|qv9xsVX6gea8p9zgFia5bKwVn0SvSMrqTVut3ecZbc714e96
+  token: 1|5P4WExZyZYxDmzYRwSRlUb1gizIxlprPzZZ0JXf9f5c8252f
 }

--- a/docs/bruno/JournalOS/environments/Local.bru
+++ b/docs/bruno/JournalOS/environments/Local.bru
@@ -1,3 +1,3 @@
 vars {
-  URL: memoir.test/api
+  URL: journalos.test/api
 }

--- a/resources/views/app/settings/profile/partials/details.blade.php
+++ b/resources/views/app/settings/profile/partials/details.blade.php
@@ -30,6 +30,9 @@
       <!-- locale -->
       <x-select id="locale" :label="__('Language')" :options="['en' => __('English'), 'fr' => __('French')]" selected="{{ $user->locale }}" required :error="$errors->get('locale')" />
 
+      <!-- time format -->
+      <x-select id="time_format_24h" :label="__('Time format')" :options="['true' => __('24-hour (e.g., 14:00)'), 'false' => __('12-hour (e.g., 2:00 PM)')]" selected="{{ $user->time_format_24h ? 'true' : 'false' }}" required :error="$errors->get('time_format_24h')" />
+
       <div class="flex items-center justify-end">
         <x-button>{{ __('Save') }}</x-button>
       </div>

--- a/resources/views/marketing/docs/api/account/api-management.blade.php
+++ b/resources/views/marketing/docs/api/account/api-management.blade.php
@@ -88,7 +88,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/settings/api" verb="GET" verbClass="text-blue-700">
-          @include('docs.api.partials.api-response')
+          @include('marketing.docs.api.partials.api-response')
         </x-marketing.docs.code>
       </div>
     </div>
@@ -125,7 +125,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/settings/api/{id}" verb="GET" verbClass="text-blue-700">
-          @include('docs.api.partials.api-response')
+          @include('marketing.docs.api.partials.api-response')
         </x-marketing.docs.code>
       </div>
     </div>
@@ -162,7 +162,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/settings/api" verb="POST" verbClass="text-green-700">
-          @include('docs.api.partials.api-response')
+          @include('marketing.docs.api.partials.api-response')
         </x-marketing.docs.code>
       </div>
     </div>

--- a/resources/views/marketing/docs/api/account/logs.blade.php
+++ b/resources/views/marketing/docs/api/account/logs.blade.php
@@ -73,7 +73,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/settings/logs" verb="GET" verbClass="text-blue-700">
-          @include('docs.api.partials.log-response')
+          @include('marketing.docs.api.partials.log-response')
         </x-marketing.docs.code>
       </div>
     </div>
@@ -109,7 +109,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/settings/logs/{log}" verb="GET" verbClass="text-blue-700">
-          @include('docs.api.partials.log-response')
+          @include('marketing.docs.api.partials.log-response')
         </x-marketing.docs.code>
       </div>
     </div>

--- a/resources/views/marketing/docs/api/account/profile.blade.php
+++ b/resources/views/marketing/docs/api/account/profile.blade.php
@@ -63,6 +63,7 @@
           <x-marketing.docs.attribute name="nickname" type="string" description="The nickname of the user." />
           <x-marketing.docs.attribute name="email" type="string" description="The email of the user." />
           <x-marketing.docs.attribute name="locale" type="string" description="The locale of the user." />
+          <x-marketing.docs.attribute name="time_format_24h" type="boolean" description="Indicates whether the user prefers the 24-hour time format." />
           <x-marketing.docs.attribute name="created_at" type="integer" description="The creation date of the user, in Unix timestamp format." />
           <x-marketing.docs.attribute name="updated_at" type="integer" description="The last update date of the user, in Unix timestamp format." />
           <x-marketing.docs.attribute name="links" type="object" description="The link to access the user." />
@@ -70,7 +71,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/me" verb="GET" verbClass="text-blue-700">
-          @include('docs.api.partials.profile-response')
+          @include('marketing.docs.api.partials.profile-response')
         </x-marketing.docs.code>
       </div>
     </div>
@@ -96,6 +97,7 @@
           <x-marketing.docs.attribute name="nickname" type="string" description="The nickname of the user. Max 255 characters." />
           <x-marketing.docs.attribute name="email" required="true" type="string" description="The email of the user. This email should be unique in the instance, and we will validate the email format. Max 255 characters." />
           <x-marketing.docs.attribute name="locale" type="string" description="The locale of the user. Format: en, fr, etc. Max 255 characters." />
+          <x-marketing.docs.attribute name="time_format_24h" type="boolean" description="Indicates whether the user prefers the 24-hour time format." />
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->
@@ -107,6 +109,7 @@
           <x-marketing.docs.attribute name="nickname" type="string" description="The nickname of the user." />
           <x-marketing.docs.attribute name="email" type="string" description="The email of the user." />
           <x-marketing.docs.attribute name="locale" type="string" description="The locale of the user." />
+          <x-marketing.docs.attribute name="time_format_24h" type="boolean" description="Indicates whether the user prefers the 24-hour time format." />
           <x-marketing.docs.attribute name="created_at" type="integer" description="The creation date of the user, in Unix timestamp format." />
           <x-marketing.docs.attribute name="updated_at" type="integer" description="The last update date of the user, in Unix timestamp format." />
           <x-marketing.docs.attribute name="links" type="object" description="The link to access the user." />
@@ -114,7 +117,7 @@
       </div>
       <div>
         <x-marketing.docs.code title="/api/me" verb="PUT" verbClass="text-yellow-700">
-          @include('docs.api.partials.profile-response')
+          @include('marketing.docs.api.partials.profile-response')
         </x-marketing.docs.code>
       </div>
     </div>

--- a/resources/views/marketing/docs/api/partials/profile-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/profile-response.blade.php
@@ -37,6 +37,11 @@
   ,
 </div>
 <div class="pl-12">
+  "time_format_24h":
+  <span class="text-lime-700">true</span>
+  ,
+</div>
+<div class="pl-12">
   "created_at":
   <span class="text-rose-800">1715145600</span>
   ,

--- a/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
@@ -25,6 +25,7 @@ final class ProfileControllerTest extends TestCase
                 'nickname',
                 'email',
                 'locale',
+                'time_format_24h',
                 'created_at',
                 'updated_at',
             ],
@@ -44,6 +45,7 @@ final class ProfileControllerTest extends TestCase
             'email' => 'michael.scott@dundermifflin.com',
             'nickname' => 'Mike',
             'locale' => 'en',
+            'time_format_24h' => true,
         ]);
 
         Sanctum::actingAs($user);
@@ -63,6 +65,7 @@ final class ProfileControllerTest extends TestCase
                     'nickname' => 'Mike',
                     'email' => 'michael.scott@dundermifflin.com',
                     'locale' => 'en',
+                    'time_format_24h' => true,
                     'created_at' => Carbon::now()->timestamp,
                     'updated_at' => Carbon::now()->timestamp,
                 ],
@@ -80,6 +83,7 @@ final class ProfileControllerTest extends TestCase
             'email' => 'michael.scott@dundermifflin.com',
             'nickname' => 'Mike',
             'locale' => 'en',
+            'time_format_24h' => true,
         ]);
 
         Sanctum::actingAs($user);
@@ -90,6 +94,7 @@ final class ProfileControllerTest extends TestCase
             'email' => 'dwight.schrute@dundermifflin.com',
             'nickname' => 'Dwight',
             'locale' => 'fr',
+            'time_format_24h' => false,
         ]);
 
         $response->assertStatus(200);
@@ -105,6 +110,7 @@ final class ProfileControllerTest extends TestCase
                     'nickname' => 'Dwight',
                     'email' => 'dwight.schrute@dundermifflin.com',
                     'locale' => 'fr',
+                    'time_format_24h' => false,
                     'created_at' => Carbon::now()->timestamp,
                     'updated_at' => Carbon::now()->timestamp,
                 ],

--- a/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
@@ -34,6 +34,7 @@ final class ProfileControllerTest extends TestCase
                 'nickname' => 'Michael',
                 'email' => 'michael.scott@dundermifflin.com',
                 'locale' => 'en',
+                'time_format_24h' => 'true',
             ]);
 
         $response
@@ -48,6 +49,7 @@ final class ProfileControllerTest extends TestCase
         $this->assertEquals('michael.scott@dundermifflin.com', $user->email);
         $this->assertEquals('en', $user->locale);
         $this->assertNull($user->email_verified_at);
+        $this->assertTrue($user->time_format_24h);
     }
 
     #[Test]
@@ -63,6 +65,7 @@ final class ProfileControllerTest extends TestCase
                 'nickname' => 'Michael',
                 'email' => $user->email,
                 'locale' => 'en',
+                'time_format_24h' => 'true',
             ]);
 
         $response
@@ -87,6 +90,7 @@ final class ProfileControllerTest extends TestCase
                 'nickname' => 'Michael',
                 'email' => $user->email,
                 'locale' => 'en',
+                'time_format_24h' => 'true',
             ]);
 
         $response

--- a/tests/Unit/Actions/UpdateUserInformationTest.php
+++ b/tests/Unit/Actions/UpdateUserInformationTest.php
@@ -37,6 +37,7 @@ final class UpdateUserInformationTest extends TestCase
             lastName: 'Scott',
             nickname: 'Mike',
             locale: 'fr',
+            timeFormat24h: false,
         ))->execute();
 
         $this->assertInstanceOf(User::class, $updatedUser);
@@ -49,6 +50,7 @@ final class UpdateUserInformationTest extends TestCase
         $this->assertEquals('Scott', $userInDb->last_name);
         $this->assertEquals('Mike', $userInDb->nickname);
         $this->assertEquals('fr', $userInDb->locale);
+        $this->assertFalse($userInDb->time_format_24h);
 
         Queue::assertPushedOn(
             queue: 'low',
@@ -85,6 +87,7 @@ final class UpdateUserInformationTest extends TestCase
             lastName: 'Schrute',
             nickname: 'Dwight',
             locale: 'fr',
+            timeFormat24h: true,
         ))->execute();
 
         Event::assertDispatched(Registered::class);
@@ -109,6 +112,7 @@ final class UpdateUserInformationTest extends TestCase
             lastName: 'Schrute',
             nickname: 'Dwight',
             locale: 'fr',
+            timeFormat24h: true,
         ))->execute();
 
         Event::assertNotDispatched(Registered::class);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: User Time Format Preference

- **New Feature**: Added user time format preference to allow users to choose between 24-hour and 12-hour time display formats
- **Database**: Added `time_format_24h` boolean column to users table with default value of `true`
- **User Model**: Updated User model with `time_format_24h` attribute, including proper casting and mass-assignment support
- **Settings UI**: Added time format selector dropdown in profile settings page (24-hour and 12-hour options)
- **API Updates**: 
  - Added `time_format_24h` boolean parameter to profile update endpoints (both web and API)
  - Exposed `time_format_24h` in UserResource JSON response
  - Updated API documentation to reflect the new attribute
- **Backend**: Extended `UpdateUserInformation` action to accept and persist time format preference
- **Testing**: Comprehensive test coverage added for the new time format feature across feature and unit tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->