### PR TITLE
feat: calculate sleep duration

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,15 +1,24 @@
 {
-  "app/Http/Controllers/Api/*.php": {
-    "alternate": "tests/Feature/Controllers/Api/{}Test.php"
+  "app/Actions/*.php": {
+    "alternate": "tests/Unit/Actions/{}Test.php"
+  },
+  "app/Console/Commands/*.php": {
+    "alternate": "tests/Unit/Console/Commands/{}Test.php"
+  },
+  "app/Helpers/Modules/*.php": {
+    "alternate": "tests/Unit/Helpers/Modules/{}Test.php"
+  },
+  "app/Helpers/*.php": {
+    "alternate": "tests/Unit/Helpers/{}Test.php"
   },
   "app/Http/Controllers/*.php": {
     "alternate": "tests/Feature/Controllers/{}Test.php"
   },
+  "app/Http/Controllers/**/*.php": {
+    "alternate": "tests/Feature/Controllers/{}Test.php"
+  },
   "app/Http/ViewModels/*.php": {
     "alternate": "tests/Unit/ViewModels/{}Test.php"
-  },
-  "app/Actions/*.php": {
-    "alternate": "tests/Unit/Actions/{}Test.php"
   },
   "app/Jobs/*.php": {
     "alternate": "tests/Unit/Jobs/{}Test.php"
@@ -26,17 +35,26 @@
   "app/View/Components/*.php": {
     "alternate": "tests/Unit/View/Components/{}Test.php"
   },
-  "tests/Feature/Controllers/Api/*Test.php": {
-    "alternate": "app/Http/Controllers/Api/{}.php"
+  "app/View/Presenters/*.php": {
+    "alternate": "tests/Unit/Presenters/{}Test.php"
   },
   "tests/Feature/Controllers/*Test.php": {
     "alternate": "app/Http/Controllers/{}.php"
   },
-  "tests/Unit/ViewModels/*Test.php": {
-    "alternate": "app/Http/ViewModels/{}.php"
+  "tests/Feature/Controllers/**/*Test.php": {
+    "alternate": "app/Http/Controllers/{}.php"
   },
   "tests/Unit/Actions/*Test.php": {
     "alternate": "app/Actions/{}.php"
+  },
+  "tests/Unit/Console/Commands/*Test.php": {
+    "alternate": "app/Console/Commands/{}.php"
+  },
+  "tests/Unit/Helpers/Modules/*Test.php": {
+    "alternate": "app/Helpers/Modules/{}.php"
+  },
+  "tests/Unit/Helpers/*Test.php": {
+    "alternate": "app/Helpers/{}.php"
   },
   "tests/Unit/Jobs/*Test.php": {
     "alternate": "app/Jobs/{}.php"
@@ -47,10 +65,16 @@
   "tests/Unit/Models/*Test.php": {
     "alternate": "app/Models/{}.php"
   },
+  "tests/Unit/Presenters/*Test.php": {
+    "alternate": "app/View/Presenters/{}.php"
+  },
   "tests/Unit/Providers/*Test.php": {
     "alternate": "app/Providers/{}.php"
   },
   "tests/Unit/View/Components/*Test.php": {
     "alternate": "app/View/Components/{}.php"
+  },
+  "tests/Unit/ViewModels/*Test.php": {
+    "alternate": "app/Http/ViewModels/{}.php"
   }
 }

--- a/app/Actions/LogBedTime.php
+++ b/app/Actions/LogBedTime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CalculateSleepDuration;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class LogBedTime
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->calculateSleepDuration();
 
         return $this->entry;
     }
@@ -67,5 +69,10 @@ final readonly class LogBedTime
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function calculateSleepDuration(): void
+    {
+        CalculateSleepDuration::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogWakeUpTime.php
+++ b/app/Actions/LogWakeUpTime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CalculateSleepDuration;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class LogWakeUpTime
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->calculateSleepDuration();
 
         return $this->entry;
     }
@@ -67,5 +69,10 @@ final readonly class LogWakeUpTime
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function calculateSleepDuration(): void
+    {
+        CalculateSleepDuration::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Jobs/CalculateSleepDuration.php
+++ b/app/Jobs/CalculateSleepDuration.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use App\Models\JournalEntry;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * Calculate the sleep duration of the given journal entry.
+ * It can only be calculated if the bedtime and wake up time are set.
+ */
+final class CalculateSleepDuration implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public JournalEntry $entry,
+    ) {}
+
+    public function handle(): void
+    {
+        if ($this->entry->bedtime === null || $this->entry->wake_up_time === null) {
+            return;
+        }
+
+        $this->entry->sleep_duration_in_minutes = $this->calculateSleepDuration();
+        $this->entry->save();
+    }
+
+    private function calculateSleepDuration(): string
+    {
+        $bedtime = Date::createFromFormat('H:i', $this->entry->bedtime);
+        $wake_up_time = Date::createFromFormat('H:i', $this->entry->wake_up_time);
+        return (string) $wake_up_time->diffInMinutes($bedtime);
+    }
+}

--- a/app/Jobs/CalculateSleepDuration.php
+++ b/app/Jobs/CalculateSleepDuration.php
@@ -34,7 +34,13 @@ final class CalculateSleepDuration implements ShouldQueue
     private function calculateSleepDuration(): string
     {
         $bedtime = Date::createFromFormat('H:i', $this->entry->bedtime);
-        $wake_up_time = Date::createFromFormat('H:i', $this->entry->wake_up_time);
-        return (string) $wake_up_time->diffInMinutes($bedtime);
+        $wakeUpTime = Date::createFromFormat('H:i', $this->entry->wake_up_time);
+
+        // If wake up time is earlier than bedtime, it means we crossed midnight
+        if ($wakeUpTime < $bedtime) {
+            $wakeUpTime = $wakeUpTime->addDay();
+        }
+
+        return (string) $wakeUpTime->diffInMinutes($bedtime, true);
     }
 }

--- a/tests/Unit/Actions/LogBedTimeTest.php
+++ b/tests/Unit/Actions/LogBedTimeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogBedTime;
+use App\Jobs\CalculateSleepDuration;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -53,6 +54,14 @@ final class LogBedTimeTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CalculateSleepDuration::class,
+            callback: function (CalculateSleepDuration $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogWakeUpTimeTest.php
+++ b/tests/Unit/Actions/LogWakeUpTimeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogWakeUpTime;
+use App\Jobs\CalculateSleepDuration;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -53,6 +54,14 @@ final class LogWakeUpTimeTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CalculateSleepDuration::class,
+            callback: function (CalculateSleepDuration $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Jobs/CalculateSleepDurationTest.php
+++ b/tests/Unit/Jobs/CalculateSleepDurationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\CalculateSleepDuration;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CalculateSleepDurationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_calculates_sleep_duration(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '22:00',
+            'wake_up_time' => '06:00',
+        ]);
+
+        $job = new CalculateSleepDuration($entry);
+        $job->handle();
+
+        $entry->refresh();
+
+        $this->assertEquals(960, $entry->sleep_duration_in_minutes);
+    }
+
+    #[Test]
+    public function it_calculates_sleep_duration_with_custom_times(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '23:30',
+            'wake_up_time' => '07:45',
+        ]);
+
+        $job = new CalculateSleepDuration($entry);
+        $job->handle();
+
+        $entry->refresh();
+
+        $this->assertEquals(945, $entry->sleep_duration_in_minutes);
+    }
+
+    #[Test]
+    public function it_does_not_calculate_when_bedtime_is_null(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => null,
+            'wake_up_time' => '06:00',
+        ]);
+
+        $job = new CalculateSleepDuration($entry);
+        $job->handle();
+
+        $entry->refresh();
+
+        $this->assertNull($entry->sleep_duration_in_minutes);
+    }
+
+    #[Test]
+    public function it_does_not_calculate_when_wake_up_time_is_null(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '22:00',
+            'wake_up_time' => null,
+        ]);
+
+        $job = new CalculateSleepDuration($entry);
+        $job->handle();
+
+        $entry->refresh();
+
+        $this->assertNull($entry->sleep_duration_in_minutes);
+    }
+
+    #[Test]
+    public function it_does_not_calculate_when_both_times_are_null(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => null,
+            'wake_up_time' => null,
+        ]);
+
+        $job = new CalculateSleepDuration($entry);
+        $job->handle();
+
+        $entry->refresh();
+
+        $this->assertNull($entry->sleep_duration_in_minutes);
+    }
+}

--- a/tests/Unit/Jobs/CalculateSleepDurationTest.php
+++ b/tests/Unit/Jobs/CalculateSleepDurationTest.php
@@ -31,7 +31,7 @@ final class CalculateSleepDurationTest extends TestCase
 
         $entry->refresh();
 
-        $this->assertEquals(960, $entry->sleep_duration_in_minutes);
+        $this->assertEquals('480', $entry->sleep_duration_in_minutes);
     }
 
     #[Test]
@@ -49,7 +49,7 @@ final class CalculateSleepDurationTest extends TestCase
 
         $entry->refresh();
 
-        $this->assertEquals(945, $entry->sleep_duration_in_minutes);
+        $this->assertEquals('495', $entry->sleep_duration_in_minutes);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added automatic sleep duration calculation that computes minutes slept when both bedtime and wake-up time are logged (handles midnight crossing)
- Introduced CalculateSleepDuration queued job (App\Jobs\CalculateSleepDuration) dispatched on the low queue to calculate and persist sleep_duration_in_minutes on a JournalEntry
- Updated LogBedTime and LogWakeUpTime actions to dispatch the CalculateSleepDuration job after updating times
- Added unit tests for CalculateSleepDuration covering normal and edge cases:
  - calculates duration across midnight (22:00 → 06:00 = 480 minutes)
  - calculates custom times (23:30 → 07:45 = 495 minutes)
  - no calculation when bedtime, wake-up time, or both are null
- Updated unit tests for LogBedTime and LogWakeUpTime to assert the CalculateSleepDuration job is dispatched
- Expanded test projection configuration (.projections.json) to map more application code locations to Unit tests and broaden test-path aliases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->