### PR TITLE
feat: reset sleep data

### DIFF
--- a/TODO
+++ b/TODO
@@ -17,3 +17,7 @@
 - [x] instance panel: give free account
 - [x] add notion of trial
 - [ ] notion of denormalized data
+- [ ] display the number of entries on a month
+- [ ] year selector
+- [ ] reset sleep entries
+- [ ] hide/show modules

--- a/TODO
+++ b/TODO
@@ -18,6 +18,7 @@
 - [x] add notion of trial
 - [ ] notion of denormalized data
 - [ ] display the number of entries on a month
+- [ ] display months containing entries
 - [ ] year selector
-- [ ] reset sleep entries
+- [x] reset sleep entries
 - [ ] hide/show modules

--- a/app/Actions/ResetSleepData.php
+++ b/app/Actions/ResetSleepData.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final readonly class ResetSleepData
+{
+    public function __construct(
+        private User $user,
+        private JournalEntry $entry,
+    ) {}
+
+    public function execute(): JournalEntry
+    {
+        $this->validate();
+        $this->entry->bedtime = null;
+        $this->entry->wake_up_time = null;
+        $this->entry->sleep_duration_in_minutes = null;
+        $this->entry->save();
+
+        $this->logUserAction();
+        $this->updateUserLastActivityDate();
+
+        return $this->entry;
+    }
+
+    private function validate(): void
+    {
+        if ($this->entry->journal->user_id !== $this->user->id) {
+            throw new ModelNotFoundException('Journal not found');
+        }
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            journal: $this->entry->journal,
+            action: 'sleep_data_reset',
+            description: 'Reset sleep data for journal entry on ' . $this->entry->getDate(),
+        )->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+}

--- a/app/Http/Controllers/App/Journals/Modules/Sleep/SleepResetController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Sleep/SleepResetController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\App\Journals\Modules\Sleep;
+
+use App\Actions\ResetSleepData;
+use App\Http\Controllers\Controller;
+use App\View\Presenters\SleepModulePresenter;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class SleepResetController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $journalEntry = $request->attributes->get('journal_entry');
+
+        new ResetSleepData(
+            user: Auth::user(),
+            entry: $journalEntry,
+        )->execute();
+
+        $module = new SleepModulePresenter($journalEntry)->build();
+
+        return to_route('journal.entry.show', [
+            'slug' => $journalEntry->journal->slug,
+            'year' => $journalEntry->year,
+            'month' => $journalEntry->month,
+            'day' => $journalEntry->day,
+            'module' => $module,
+        ])->with('status', __('Changes saved'));
+    }
+}

--- a/app/View/Presenters/SleepModulePresenter.php
+++ b/app/View/Presenters/SleepModulePresenter.php
@@ -63,6 +63,27 @@ final readonly class SleepModulePresenter
             'wake_up_time' => SleepHelper::shift($wake_up_time, +5),
         ]);
 
+        $bedtimeUpdateUrl = route('journal.entry.sleep.bedtime.update', [
+            'slug' => $this->entry->journal->slug,
+            'year' => $this->entry->year,
+            'month' => $this->entry->month,
+            'day' => $this->entry->day,
+        ]);
+
+        $wakeUpTimeUpdateUrl = route('journal.entry.sleep.wake_up_time.update', [
+            'slug' => $this->entry->journal->slug,
+            'year' => $this->entry->year,
+            'month' => $this->entry->month,
+            'day' => $this->entry->day,
+        ]);
+
+        $resetUrl = route('journal.entry.sleep.reset', [
+            'slug' => $this->entry->journal->slug,
+            'year' => $this->entry->year,
+            'month' => $this->entry->month,
+            'day' => $this->entry->day,
+        ]);
+
         return [
             'bedtime' => $bedtimeRange,
             'wake_up_time' => $wakeUpRange,
@@ -70,18 +91,10 @@ final readonly class SleepModulePresenter
             'next_bedtime_url' => $nextBedtimeUrl,
             'previous_wake_up_url' => $previousWakeUpUrl,
             'next_wake_up_url' => $nextWakeUpUrl,
-            'bedtime_update_url' => route('journal.entry.sleep.bedtime.update', [
-                'slug' => $this->entry->journal->slug,
-                'year' => $this->entry->year,
-                'month' => $this->entry->month,
-                'day' => $this->entry->day,
-            ]),
-            'wake_up_time_update_url' => route('journal.entry.sleep.wake_up_time.update', [
-                'slug' => $this->entry->journal->slug,
-                'year' => $this->entry->year,
-                'month' => $this->entry->month,
-                'day' => $this->entry->day,
-            ]),
+            'bedtime_update_url' => $bedtimeUpdateUrl,
+            'wake_up_time_update_url' => $wakeUpTimeUpdateUrl,
+            'reset_url' => $resetUrl,
+            'display_reset' => ! is_null($this->entry->bedtime) || ! is_null($this->entry->wake_up_time),
         ];
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -1130,24 +1130,24 @@
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3"
+                "phpoption/phpoption": "^1.9.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
             "type": "library",
             "autoload": {
@@ -1176,7 +1176,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -1188,7 +1188,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:45:45+00:00"
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3473,16 +3473,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -3532,7 +3532,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -3544,7 +3544,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T11:53:16+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -7297,26 +7297,26 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.2",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.3",
+                "graham-campbell/result-type": "^1.1.4",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3",
-                "symfony/polyfill-ctype": "^1.24",
-                "symfony/polyfill-mbstring": "^1.24",
-                "symfony/polyfill-php80": "^1.24"
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -7365,7 +7365,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
             },
             "funding": [
                 {
@@ -7377,7 +7377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-30T23:37:27+00:00"
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "voku/portable-ascii",

--- a/database/blacklist_domains/data.txt
+++ b/database/blacklist_domains/data.txt
@@ -80,6 +80,7 @@
 4qqf6.anonbox.net
 4wd2b.anonbox.net
 4whole.com
+4xo3i.anonbox.net
 4xoay.com
 504333.xyz
 524446913.xyz
@@ -229,7 +230,6 @@ aikoreaedu.com
 aikunkun.com
 aimsa.shop
 aiqoe.com
-aircraftsa.online
 airmail.top
 airmailbox.website
 airsworld.net
@@ -326,14 +326,12 @@ animalkingdo.com
 animalsa.shop
 anique.pro
 anjay.id
-anklesa.online
 anlocc.com
 anlzdroidwe.top
 anmmo2024.com
 annavogue.shop
 anniversarysa.online
 announcesa.site
-annoysa.shop
 anonimsirketmail.com.tr
 anonimsirketmail.online
 anonimsirketmail.xyz
@@ -724,7 +722,6 @@ bl36v.anonbox.net
 blabel.online
 blackhosting.online
 blaxion.com
-blazemail.me
 blbkf.anonbox.net
 blbt5.anonbox.net
 bldmovie.com
@@ -893,6 +890,7 @@ buminurullah.io
 bung.holio.day
 burangir.com
 businesscell.network
+bussinesa.app
 busykitchen.com
 buviz.anonbox.net
 buwt2.anonbox.net
@@ -1580,7 +1578,6 @@ etics.us
 etiqets.biz
 etramay.com
 eu3ih.anonbox.net
-eudaimonias.work
 euesolucoes.online
 euleina.com
 evexia-cosmetics.de
@@ -2027,6 +2024,7 @@ hieuvia.top
 highenddesign.site
 highstar.shop
 highstudios.net
+higogoya.com
 hihi.lol
 hikuhu.com
 himkinet.ru
@@ -2348,7 +2346,6 @@ kaybooks.top
 kayfilms.top
 kayserilimusti.network
 kazinkana.com
-kb4gx.anonbox.net
 kbw5m.anonbox.net
 kcmh5.anonbox.net
 kcum7.anonbox.net
@@ -2682,7 +2679,6 @@ mailhieu2.store
 mailhvd.lat
 maili.fun
 mailinator.com
-mailinux.me
 mailku.shop
 maillasd1.trade
 mailmag.info
@@ -3277,7 +3273,6 @@ parkers4events.com
 parkertufan.shop
 pasarakun.art
 pasarakun.me
-passplot.ch
 past-line.com
 pastipass.com
 pastryofistanbul.com
@@ -3285,6 +3280,7 @@ patance.com
 patity.com
 patrickmeinhardt.de
 pawtopup.com
+pay-pp.top
 pay-us.lol
 payposs.com
 paytesacard.app
@@ -3932,7 +3928,6 @@ t.woeishyang.com
 t0o.us
 t4a6t.anonbox.net
 t63uz.anonbox.net
-t7s.us
 ta-sg.top
 tabgs-sg.xyz
 tabletship.com

--- a/database/blacklist_domains/domains.txt
+++ b/database/blacklist_domains/domains.txt
@@ -2829,6 +2829,7 @@
 6brmwv.ml
 6brmwv.tk
 6cq9epnn.edu.pl
+6dy.store
 6ed9cit4qpxrcngbq.cf
 6ed9cit4qpxrcngbq.ga
 6ed9cit4qpxrcngbq.gq
@@ -6414,6 +6415,7 @@ anhalim.me
 anhaysuka.com
 anheakao.xyz
 anhhungrom47.xyz
+anhmaybietchoi.com
 anhthu.org
 anhudsb.com
 anhvip9999.com
@@ -7617,6 +7619,7 @@ atmodule.com
 atmospheremaxhomes.us
 atnextmail.com
 atolyezen.com
+atomicmail.io
 atoyot.cf
 atoyot.ga
 atoyot.gq
@@ -7670,6 +7673,7 @@ atwellpublishing.com
 atx.emltmp.com
 atxcrunner.com
 atyc.laste.ml
+au-1.top
 auan.dropmail.me
 aub.emlpro.com
 aubady.com
@@ -7914,6 +7918,7 @@ availablewibowo.biz
 avainternational.com
 avaliaboards.com
 avalins.com
+avalonminer.cloud
 avalonrx.com
 avalonyouth.com
 avanafilprime.com
@@ -8576,6 +8581,7 @@ b6c4g.anonbox.net
 b6c7g.anonbox.net
 b6faz.anonbox.net
 b6fm5.anonbox.net
+b6kgo.anonbox.net
 b6lgf.anonbox.net
 b6muz.anonbox.net
 b6o7vt32yz.cf
@@ -9147,6 +9153,7 @@ bathandbodyworksoutlettest.org
 bathedandinfused.com
 bathroomsbristol.com
 bathworks.info
+batikmpo.top
 batlmamad.gq
 batpat.it
 batpeer.site
@@ -9194,6 +9201,7 @@ bazoocam.co
 bazookagoldtrap.com
 bazreno.com
 bazybgumui.pl
+bb-a.top
 bb-system.pl
 bb1197.com
 bb2.ru
@@ -11026,6 +11034,7 @@ bnv0qx4df0quwiuletg.ml
 bnv0qx4df0quwiuletg.tk
 bnx53.anonbox.net
 bnxuh.anonbox.net
+bnyhr.us
 bnyzw.info
 bnz.dropmail.me
 bnzlu.anonbox.net
@@ -11473,6 +11482,7 @@ bossman.chat
 bossmanjack.lol
 bossmanjack.shop
 bossmanjack.store
+bossmanjack.xyz
 bosterpremium.com
 bostonhydraulic.com
 bostonplanet.com
@@ -13094,6 +13104,7 @@ cantouri.com
 cantozil.com
 cantsleep.gq
 canuster.xyz
+canvaedu.id
 canvagiare.me
 canvasarttalk.com
 canvasshoeswholesalestoress.info
@@ -13487,7 +13498,6 @@ cbv.com
 cbyourself.com
 cbzmail.tk
 cc-cc.usa.cc
-cc-prem.store
 cc-s3x.cf
 cc-s3x.ga
 cc-s3x.gq
@@ -14521,6 +14531,7 @@ chsl.tk
 chsp.com
 chteam.net
 chuacotsong.online
+chuan.info
 chubbyteenmodels.com
 chuckbennettcontracting.com
 chuckbrockman.com
@@ -15538,7 +15549,6 @@ componentartscstamp.store
 compoundtown.com
 comprabula.pt
 comprar-com-desconto.com
-comprarcapcut.shop
 compraresteroides.xyz
 comprarfarmacia.site
 comprehensivesearchinitiatives.com
@@ -16385,7 +16395,6 @@ cubicleremoval.ca
 cubiclink.com
 cubicview.site
 cubox.biz.st
-cucimata.online
 cuckmere.org.uk
 cucku.cf
 cucku.ml
@@ -16439,6 +16448,7 @@ cuoiz.com
 cuoly.com
 cuong.bid
 cuongaquarium.com
+cuongkigu.xyz
 cuongrmfwbnpl43.online
 cuongtaote.com
 cuongvumarketingseo.com
@@ -17992,6 +18002,7 @@ developer.martinandgang.com
 developermail.com
 developfuel.com
 developmentwebsite.co.uk
+developtool.app
 develoverpack.systems
 develow.site
 develows.site
@@ -22597,6 +22608,7 @@ evilant.com
 evilbruce.com
 evilcomputer.com
 evilgodshop.com
+evilgodshop2.uk
 evilin-expo.ru
 evimzo.com
 evkiwi.de
@@ -27052,6 +27064,7 @@ gloria-tours.com
 gloriousfuturedays.com
 glorysteak.email
 gloservma.com
+glossier-group.com
 glossybee.com
 glovebranders.com
 glovesprotection.info
@@ -27646,6 +27659,7 @@ google2u.com
 googleappmail.com
 googleappsmail.com
 googlebox.com
+googlebox.kr
 googlecn.com
 googledottrick.com
 googlefind.com
@@ -28467,6 +28481,7 @@ gzek.emlpro.com
 gzesiek84bb.pl
 gzk.mimimail.me
 gzk2sjhj9.pl
+gzley.site
 gzo.laste.ml
 gzq.emlhub.com
 gzr.spymail.one
@@ -31696,6 +31711,7 @@ iloov.eu
 iloplr.com
 ilopopolp.com
 ilove.com
+ilove4.skin
 ilovebh.ml
 ilovecorgistoo.com
 iloveearthtunes.com
@@ -32221,7 +32237,6 @@ insgrmail.site
 inshapeactive.ru
 inshuan.com
 insidegpus.com
-insiderecholink.com
 insidershq.info
 insidiousahmadi.biz
 insighbb.com
@@ -32841,6 +32856,7 @@ itecsgroup.org
 itekc.com
 itekcorp.com
 itemailing.com
+itemku.cfd
 itemp.email
 itempmail.tk
 iteradev.com
@@ -33679,7 +33695,6 @@ jhow.ga
 jhow.gq
 jhow.ml
 jhp.emlhub.com
-jhphoto.top
 jhptraining.com
 jhsn.freeml.net
 jhsss.biz
@@ -34402,6 +34417,7 @@ junk.noplay.org
 junk.to
 junk.vanillasystem.com
 junk1e.com
+junk4.me
 junkgrid.com
 junklessmaildaemon.info
 junkmail.com
@@ -35980,6 +35996,7 @@ kmuye.xyz
 kmvdizyz.shop
 kmwtevepdp178.gq
 kn.freeml.net
+kn0wme.tech
 kn7il8fp1.pl
 kna.emltmp.com
 knaiji.com
@@ -36950,12 +36967,14 @@ lahta9qru6rgd.ga
 lahta9qru6rgd.gq
 lahta9qru6rgd.ml
 lahta9qru6rgd.tk
+laicai8.sbs
 laika999.ml
 laikacyber.cf
 laikacyber.ga
 laikacyber.gq
 laikacyber.ml
 laikacyber.tk
+lailakhan.net
 lain.ch
 lajdneewow.download
 lajoska.pe.hu
@@ -38595,6 +38614,7 @@ loofty.com
 look.cowsnbullz.com
 look.lakemneadows.com
 look.oldoutnewin.com
+lookbek.cfd
 lookingthe.com
 looklemsun.uni.me
 lookmail.ml
@@ -38781,6 +38801,7 @@ love-your.mom
 love.info
 love.vo.uk
 love365.ru
+love4.skin
 love4writing.info
 lovea.site
 loveabledress.com
@@ -40539,6 +40560,7 @@ mailmailv.eu
 mailmall.online
 mailman.com
 mailmanbeat.club
+mailmask.cc
 mailmassa.info
 mailmate.com
 mailmaxy.one
@@ -41538,6 +41560,7 @@ matydezynfekcyjne.com.pl
 matzan-fried.com
 matzxcv.org
 mau.laste.ml
+mau.my.id
 maujadieskrim.fun
 mauler.ru
 mauricemagazine.com
@@ -41623,6 +41646,7 @@ mayorpoker.net
 mayposre.ga
 mayschemical.com
 maysunsaluki.com
+maytinhvinhlong.info.vn
 maytree.ru
 mazaevka.ru
 mazedojo.com
@@ -45182,7 +45206,6 @@ nedt.net
 nedtwo.cloud
 neeahoniy.com
 need-mail.com
-need53.sbs
 needaprint.co.uk
 needidoo.org.ua
 needlegqu.com
@@ -45784,6 +45807,7 @@ nic.com.au
 nic58.com
 nice-4u.com
 nice-tits.info
+nicebad.com
 nicebeads.biz
 nicecatbook.site
 nicecatfiles.site
@@ -47787,6 +47811,7 @@ onepiece-vostfr.stream
 onepiecetalkblog.com
 onepvp.com
 onestepaboveclean.org
+onestepgpt.tech
 onestepmail.com
 onestop21.com
 onestopwv.com
@@ -49758,6 +49783,7 @@ pharmshop-online.com
 pharmwalmart.com
 pharusa.biz
 pharveta.ga
+phatculol.click
 phatinterior.click
 phatmail.net
 phatrukhabaenglish.education
@@ -50645,6 +50671,7 @@ pordiosw.com
 pordpopogame.com
 poreglot.ru
 porevoorevo.co.cc
+porhantek.shop
 poribikers.tk
 porilo.com
 porjoton.com
@@ -52449,7 +52476,6 @@ qrd6gzhb48.xorg.pl
 qreciclas.com
 qrl.emlhub.com
 qrlv.mailpwr.com
-qrmta.works
 qrn.emlhub.com
 qrno1i.info
 qro.dropmail.me
@@ -53786,7 +53812,6 @@ reliefteam.com
 religionguru.ru
 religioussearch.com
 relisticworld.world
-relivacca.cfd
 relleano.com
 relliklondon.com
 relmarket.com
@@ -55881,6 +55906,7 @@ santuyy.tech
 sanvekhuyenmai.com
 sanvetetre.com
 sanzv.com
+saoluudulieu.beauty
 saoulere.ml
 sapbox.bid
 sapcom.org
@@ -58825,6 +58851,7 @@ sparkmate.lat
 sparkpool.info
 sparkpoolprohub.online
 sparkroi.com
+sparkunity.lat
 sparkypremium.com
 sparramail.info
 sparrowcrew.org
@@ -58841,6 +58868,7 @@ spblt.ru
 spdplumbing-heating.co.uk
 spduszniki.pl
 spe24.de
+speak2all.com
 speakfreely.email
 speakfreely.legal
 spearsmail.men
@@ -59018,6 +59046,7 @@ spotoid.com
 spoty.email
 spotyprot.live
 spotyprot.online
+spoxtify.com
 spoyascil.my.id
 sppwgegt.mailpwr.com
 sppy.site
@@ -62775,7 +62804,6 @@ tokai.tk
 tokar.com.pl
 tokatgunestv.xyz
 tokatta.org
-tokbt.anonbox.net
 tokeishops.jp
 tokem.co
 token.ro
@@ -65101,6 +65129,7 @@ urbanchickencoop.com
 urbanforestryllc.com
 urbanized.us
 urbanlegendsvideo.com
+urbanovalife.com
 urbanovapro.com
 urbanquarter.co
 urbanspacepractice.com
@@ -67472,6 +67501,7 @@ web3453.de
 web3561.de
 webail.co.za
 webandgraphicdesignbyphil.com
+webanx.app
 webarnak.fr.eu.org
 webaward.online
 webaz.xyz

--- a/lang/en.json
+++ b/lang/en.json
@@ -146,6 +146,7 @@
     "Recovery codes": "Recovery codes",
     "Remember me": "Remember me",
     "Resend verification email": "Resend verification email",
+    "Reset": "Reset",
     "Reset password": "Reset password",
     "Save": "Save",
     "Saved.": "Saved.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -146,6 +146,7 @@
     "Recovery codes": "Codes de récupération",
     "Remember me": "Se souvenir de moi",
     "Resend verification email": "Renvoyer l'e-mail de vérification",
+    "Reset": "Réinitialiser",
     "Reset password": "Réinitialiser le mot de passe",
     "Save": "Enregistrer",
     "Saved.": "Enregistré.",

--- a/resources/views/app/journal/entry/partials/sleep.blade.php
+++ b/resources/views/app/journal/entry/partials/sleep.blade.php
@@ -1,6 +1,17 @@
 <x-module>
   <x-slot:title>{{ __('Sleep tracking') }}</x-slot>
   <x-slot:emoji>🌖</x-slot>
+  <x-slot:action>
+    <div id="reset">
+      @if ($module['display_reset'])
+        <x-form x-target="sleep-container notifications reset" :action="$module['reset_url']" method="put">
+          <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px]">
+            {{ __('Reset') }}
+          </button>
+        </x-form>
+      @endif
+    </div>
+  </x-slot>
 
   <div id="sleep-container" class="space-y-4">
     <div class="space-y-2">
@@ -19,7 +30,7 @@
       <div class="flex w-full rounded-lg border border-gray-200">
         @foreach ($module['bedtime'] as $option)
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0">
-            <x-form x-target="sleep-container notifications" :action="$module['bedtime_update_url']" method="put" class="h-full">
+            <x-form x-target="sleep-container notifications reset" :action="$module['bedtime_update_url']" method="put" class="h-full">
               <input type="hidden" name="bedtime" value="{{ $option['time'] }}" />
               <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50">
                 {{ \App\Helpers\TimeHelper::format($option['time']) }}
@@ -46,7 +57,7 @@
       <div class="flex w-full rounded-lg border border-gray-200">
         @foreach ($module['wake_up_time'] as $option)
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0">
-            <x-form x-target="sleep-container notifications" :action="$module['wake_up_time_update_url']" method="put" class="h-full">
+            <x-form x-target="sleep-container notifications reset" :action="$module['wake_up_time_update_url']" method="put" class="h-full">
               <input type="hidden" name="wake_up_time" value="{{ $option['time'] }}" />
               <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50">
                 {{ \App\Helpers\TimeHelper::format($option['time']) }}

--- a/resources/views/components/module.blade.php
+++ b/resources/views/components/module.blade.php
@@ -1,18 +1,25 @@
 @props([
   'title' => null,
   'emoji' => null,
+  'action' => null,
 ])
 
 <div {{ $attributes->merge(['class' => 'rounded-lg border border-gray-200 bg-white ']) }}>
-  @isset($title)
-    <div class="flex items-center border-b border-gray-200 p-2">
-      @isset($emoji)
-        <span class="mr-2">{{ $emoji }}</span>
-      @endisset
+  <div class="flex items-center justify-between border-b border-gray-200 p-2">
+    @isset($title)
+      <div class="flex items-center">
+        @isset($emoji)
+          <span class="mr-2">{{ $emoji }}</span>
+        @endisset
 
-      <h2 class="font-semibold">{{ $title }}</h2>
-    </div>
-  @endisset
+        <h2 class="font-semibold">{{ $title }}</h2>
+      </div>
+    @endisset
+
+    @isset($action)
+      {{ $action }}
+    @endisset
+  </div>
 
   <div class="p-2">
     {{ $slot }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware(['auth', 'verified', 'throttle:60,1', 'set.locale'])->group(fu
                     ->name('journal.entry.sleep.show');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/sleep/bedtime', [Journals\Modules\Sleep\SleepBedTimeController::class, 'update'])->name('journal.entry.sleep.bedtime.update');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/sleep/wake_up_time', [Journals\Modules\Sleep\SleepWakeUpTimeController::class, 'update'])->name('journal.entry.sleep.wake_up_time.update');
+                Route::put('journals/{slug}/entries/{year}/{month}/{day}/sleep/reset', [Journals\Modules\Sleep\SleepResetController::class, 'update'])->name('journal.entry.sleep.reset');
             });
         });
     });

--- a/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepResetControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepResetControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\App\Journals\Modules\Sleep;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class SleepResetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_sleep_data_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '22:00',
+            'wake_up_time' => '06:00',
+            'sleep_duration_in_minutes' => 480,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/reset",
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}");
+        $response->assertSessionHas('status');
+
+        $entry->refresh();
+        $this->assertNull($entry->bedtime);
+        $this->assertNull($entry->wake_up_time);
+        $this->assertNull($entry->sleep_duration_in_minutes);
+    }
+
+    #[Test]
+    public function it_redirects_guests_to_login(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        $response = $this->put(
+            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/reset",
+        );
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '22:00',
+            'wake_up_time' => '06:00',
+            'sleep_duration_in_minutes' => 480,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/reset",
+        );
+
+        $response->assertStatus(404);
+
+        // Sleep data should not be reset for unauthorized user
+        $entry->refresh();
+        $this->assertNotNull($entry->bedtime);
+        $this->assertNotNull($entry->wake_up_time);
+        $this->assertNotNull($entry->sleep_duration_in_minutes);
+    }
+}

--- a/tests/Unit/Actions/ResetSleepDataTest.php
+++ b/tests/Unit/Actions/ResetSleepDataTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\ResetSleepData;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ResetSleepDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_sleep_data_for_a_journal_entry(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'bedtime' => '22:30',
+            'wake_up_time' => '06:45',
+            'sleep_duration_in_minutes' => 495,
+        ]);
+
+        $result = (new ResetSleepData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+
+        $this->assertNull($result->bedtime);
+        $this->assertNull($result->wake_up_time);
+        $this->assertNull($result->sleep_duration_in_minutes);
+
+        $this->assertDatabaseHas('journal_entries', [
+            'id' => $entry->id,
+            'bedtime' => null,
+            'wake_up_time' => null,
+            'sleep_duration_in_minutes' => null,
+        ]);
+
+        $this->assertInstanceOf(JournalEntry::class, $result);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'sleep_data_reset' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_entry_does_not_belong_to_user(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Journal not found');
+
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $journal = Journal::factory()->for($otherUser)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new ResetSleepData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+    }
+}

--- a/tests/Unit/Presenters/SleepModulePresenterTest.php
+++ b/tests/Unit/Presenters/SleepModulePresenterTest.php
@@ -42,6 +42,8 @@ final class SleepModulePresenterTest extends TestCase
         $this->assertArrayHasKey('next_wake_up_url', $result);
         $this->assertArrayHasKey('bedtime_update_url', $result);
         $this->assertArrayHasKey('wake_up_time_update_url', $result);
+        $this->assertArrayHasKey('reset_url', $result);
+        $this->assertArrayHasKey('display_reset', $result);
 
         $this->assertCount(5, $result['bedtime']);
         $this->assertCount(5, $result['wake_up_time']);
@@ -148,6 +150,11 @@ final class SleepModulePresenterTest extends TestCase
 
         $this->assertStringContainsString('/01:00', $result['previous_wake_up_url']);
         $this->assertStringContainsString('/11:00', $result['next_wake_up_url']);
+
+        $this->assertStringContainsString($journal->slug, $result['reset_url']);
+        $this->assertStringContainsString('2024', $result['reset_url']);
+        $this->assertStringContainsString('12', $result['reset_url']);
+        $this->assertStringContainsString('25', $result['reset_url']);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New ResetSleepData action: clears bedtime, wake_up_time, and sleep_duration_in_minutes on a journal entry and returns the updated entry
- Ownership validation: action throws ModelNotFoundException when the entry’s journal does not belong to the user
- Controller & route: added SleepResetController with update action and a PUT route at /journals/{slug}/entries/{year}/{month}/{day}/sleep/reset (named journal.entry.sleep.reset)
- UI updates: SleepModulePresenter exposes reset_url and display_reset; sleep partial shows a Reset button when appropriate; module component adds a right-aligned action slot (prop: action)
- Background jobs: ResetSleepData dispatches low-priority LogUserAction (action: sleep_data_reset) and UpdateUserLastActivityDate
- Translations: added "Reset" key in lang/en.json and lang/fr.json
- Tests added: unit tests for ResetSleepData and SleepModulePresenter; feature tests for SleepResetController (success, guest redirect, unauthorized entry)
- Data updates: additions/removals to blacklist domain files (database/blacklist_domains/domains.txt and data.txt)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->