### PR TITLE
chore: move rename action

### DIFF
--- a/app/Http/Controllers/App/Journals/JournalController.php
+++ b/app/Http/Controllers/App/Journals/JournalController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\App\Journals;
 
 use App\Actions\CreateJournal;
 use App\Actions\DestroyJournal;
+use App\Actions\RenameJournal;
 use App\Http\Controllers\Controller;
 use App\Models\Journal;
 use Illuminate\Http\RedirectResponse;
@@ -65,6 +66,30 @@ final class JournalController extends Controller
             'month' => $month,
             'day' => $day,
         ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $journal = $request->attributes->get('journal');
+
+        $validated = $request->validate([
+            'journal_name' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:/^[a-zA-Z0-9\s\-_]+$/',
+            ],
+        ]);
+
+        new RenameJournal(
+            user: $request->user(),
+            journal: $journal,
+            name: $validated['journal_name'],
+        )->execute();
+
+        return to_route('journal.settings.show', [
+            'slug' => $journal->slug,
+        ])->with('status', __('Changes saved'));
     }
 
     public function destroy(Request $request): RedirectResponse

--- a/app/Http/Controllers/App/Journals/Settings/JournalSettingsController.php
+++ b/app/Http/Controllers/App/Journals/Settings/JournalSettingsController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\App\Journals\Settings;
 
-use App\Actions\RenameJournal;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -19,29 +17,5 @@ final class JournalSettingsController extends Controller
         return view('app.journal.settings.show', [
             'journal' => $journal,
         ]);
-    }
-
-    public function update(Request $request): RedirectResponse
-    {
-        $journal = $request->attributes->get('journal');
-
-        $validated = $request->validate([
-            'journal_name' => [
-                'required',
-                'string',
-                'max:255',
-                'regex:/^[a-zA-Z0-9\s\-_]+$/',
-            ],
-        ]);
-
-        new RenameJournal(
-            user: $request->user(),
-            journal: $journal,
-            name: $validated['journal_name'],
-        )->execute();
-
-        return to_route('journal.settings.show', [
-            'slug' => $journal->slug,
-        ])->with('status', __('Changes saved'));
     }
 }

--- a/resources/views/app/journal/settings/partials/rename.blade.php
+++ b/resources/views/app/journal/settings/partials/rename.blade.php
@@ -1,7 +1,7 @@
 <x-box padding="p-0">
   <x-slot:title>{{ __('Rename journal') }}</x-slot>
 
-  <x-form method="put" action="{{ route('journal.settings.update', ['slug' => $journal->slug]) }}">
+  <x-form method="put" action="{{ route('journal.update', ['slug' => $journal->slug]) }}">
     <div class="grid grid-cols-3 items-center rounded-t-lg border-b border-gray-200 p-3 hover:bg-blue-50">
       <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Name of the journal') }}</p>
       <div class="w-full justify-self-end">

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,7 +54,7 @@ Route::middleware(['auth', 'verified', 'throttle:60,1', 'set.locale'])->group(fu
 
             // settings
             Route::get('journals/{slug}/settings', [Journals\Settings\JournalSettingsController::class, 'show'])->name('journal.settings.show');
-            Route::put('journals/{slug}/settings', [Journals\Settings\JournalSettingsController::class, 'update'])->name('journal.settings.update');
+            Route::put('journals/{slug}', [Journals\JournalController::class, 'update'])->name('journal.update');
             Route::delete('journals/{slug}', [Journals\JournalController::class, 'destroy'])->name('journal.destroy');
         });
     });

--- a/tests/Feature/Controllers/App/Journals/JournalControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/JournalControllerTest.php
@@ -8,8 +8,8 @@ use App\Models\Journal;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 final class JournalControllerTest extends TestCase
 {
@@ -83,6 +83,54 @@ final class JournalControllerTest extends TestCase
         $response = $this->actingAs($user)->get('/journals/' . $journal->slug);
 
         $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_updates_the_journal_name(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create([
+            'name' => 'Dunder Mifflin',
+        ]);
+
+        $response = $this->actingAs($user)->put('/journals/' . $journal->slug, [
+            'journal_name' => 'Threat Level Midnight',
+        ]);
+
+        $journal->refresh();
+
+        $response->assertRedirect(route('journal.settings.show', ['slug' => $journal->slug]));
+        $response->assertSessionHas('status', 'Changes saved');
+        $this->assertEquals('Threat Level Midnight', $journal->name);
+    }
+
+    #[Test]
+    public function it_validates_the_journal_name_when_updating(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)
+            ->from('/journals/' . $journal->slug . '/settings')
+            ->put('/journals/' . $journal->slug, [
+                'journal_name' => 'Invalid@!',
+            ]);
+
+        $response->assertRedirect('/journals/' . $journal->slug . '/settings');
+        $response->assertSessionHasErrors(['journal_name']);
+    }
+
+    #[Test]
+    public function it_returns_not_found_when_trying_to_update_a_journal_the_user_does_not_own(): void
+    {
+        $user = User::factory()->create();
+        $otherJournal = Journal::factory()->create();
+
+        $response = $this->actingAs($user)->put('/journals/' . $otherJournal->slug, [
+            'journal_name' => 'Threat Level Midnight',
+        ]);
+
+        $response->assertNotFound();
     }
 
     #[Test]

--- a/tests/Feature/Controllers/App/Journals/Settings/JournalSettingsControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Settings/JournalSettingsControllerTest.php
@@ -31,60 +31,12 @@ final class JournalSettingsControllerTest extends TestCase
     }
 
     #[Test]
-    public function it_updates_the_journal_name(): void
-    {
-        $user = User::factory()->create();
-        $journal = Journal::factory()->for($user)->create([
-            'name' => 'Dunder Mifflin',
-        ]);
-
-        $response = $this->actingAs($user)->put('/journals/' . $journal->slug . '/settings', [
-            'journal_name' => 'Threat Level Midnight',
-        ]);
-
-        $journal->refresh();
-
-        $response->assertRedirect(route('journal.settings.show', ['slug' => $journal->slug]));
-        $response->assertSessionHas('status', 'Changes saved');
-        $this->assertEquals('Threat Level Midnight', $journal->name);
-    }
-
-    #[Test]
-    public function it_validates_the_journal_name_when_updating(): void
-    {
-        $user = User::factory()->create();
-        $journal = Journal::factory()->for($user)->create();
-
-        $response = $this->actingAs($user)
-            ->from('/journals/' . $journal->slug . '/settings')
-            ->put('/journals/' . $journal->slug . '/settings', [
-                'journal_name' => 'Invalid@!',
-            ]);
-
-        $response->assertRedirect('/journals/' . $journal->slug . '/settings');
-        $response->assertSessionHasErrors(['journal_name']);
-    }
-
-    #[Test]
     public function it_returns_not_found_if_user_does_not_own_the_journal(): void
     {
         $user = User::factory()->create();
         $otherJournal = Journal::factory()->create();
 
         $response = $this->actingAs($user)->get('/journals/' . $otherJournal->slug . '/settings');
-
-        $response->assertNotFound();
-    }
-
-    #[Test]
-    public function it_returns_not_found_when_trying_to_update_a_journal_the_user_does_not_own(): void
-    {
-        $user = User::factory()->create();
-        $otherJournal = Journal::factory()->create();
-
-        $response = $this->actingAs($user)->put('/journals/' . $otherJournal->slug . '/settings', [
-            'journal_name' => 'Threat Level Midnight',
-        ]);
 
         $response->assertNotFound();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Refactored**: Moved journal rename action from `JournalSettingsController` to `JournalController` for improved code organization
- **Updated**: PUT route changed from `/journals/{slug}/settings` to `/journals/{slug}` with route name `journal.update`
- **Updated**: Rename form submission now targets `journal.update` route instead of `journal.settings.update`
- **Added**: Comprehensive tests for journal update functionality including validation and authorization checks
- **No behavioral changes**: All existing functionality preserved; this is purely a structural reorganization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->