### PR TITLE
feat: add api endpoint to toggle auto-delete account

### DIFF
--- a/app/Http/Controllers/Api/Settings/Security/AutoDeleteAccountController.php
+++ b/app/Http/Controllers/Api/Settings/Security/AutoDeleteAccountController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Settings\Security;
+
+use App\Http\Controllers\Controller;
+use App\Traits\ApiResponses;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class AutoDeleteAccountController extends Controller
+{
+    use ApiResponses;
+
+    public function update(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'auto_delete_account' => ['required', 'in:yes,no'],
+        ]);
+
+        $user = Auth::user();
+        $user->auto_delete_account = $validated['auto_delete_account'] === 'yes';
+        $user->save();
+
+        return $this->ok(trans('Changes saved'));
+    }
+}

--- a/app/Http/Controllers/Api/Settings/Security/AutoDeleteAccountController.php
+++ b/app/Http/Controllers/Api/Settings/Security/AutoDeleteAccountController.php
@@ -17,11 +17,11 @@ final class AutoDeleteAccountController extends Controller
     public function update(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'auto_delete_account' => ['required', 'in:yes,no'],
+            'auto_delete_account' => ['required', 'boolean'],
         ]);
 
         $user = Auth::user();
-        $user->auto_delete_account = $validated['auto_delete_account'] === 'yes';
+        $user->auto_delete_account = (bool) $validated['auto_delete_account'];
         $user->save();
 
         return $this->ok(trans('Changes saved'));

--- a/app/Http/Controllers/App/Settings/Security/AutoDeleteAccountController.php
+++ b/app/Http/Controllers/App/Settings/Security/AutoDeleteAccountController.php
@@ -15,12 +15,12 @@ final class AutoDeleteAccountController extends Controller
     public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'auto_delete_account' => ['required', 'in:yes,no'],
+            'auto_delete_account' => ['required', 'boolean'],
         ]);
 
         $user = User::query()->find(Auth::user()->id);
 
-        $user->auto_delete_account = $validated['auto_delete_account'] === 'yes';
+        $user->auto_delete_account = (bool) $validated['auto_delete_account'];
         $user->save();
 
         return to_route('settings.security.index')

--- a/docs/bruno/JournalOS/Auto Delete Account.bru
+++ b/docs/bruno/JournalOS/Auto Delete Account.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Auto delete account
+  type: http
+  seq: 3
+}
+
+put {
+  url: http://{{URL}}/api/settings/security/auto-delete-account
+  body: json
+  auth: inherit
+}
+
+body:json {
+  "auto_delete_account": "yes"
+}

--- a/docs/bruno/JournalOS/Auto Delete Account.bru
+++ b/docs/bruno/JournalOS/Auto Delete Account.bru
@@ -11,5 +11,5 @@ put {
 }
 
 body:json {
-  "auto_delete_account": "yes"
+  "auto_delete_account": true
 }

--- a/resources/views/marketing/docs/api/account/account.blade.php
+++ b/resources/views/marketing/docs/api/account/account.blade.php
@@ -8,6 +8,10 @@
 
     <x-marketing.docs.table-of-content :items="[
       [
+        'id' => 'auto-delete-the-account',
+        'title' => 'Auto delete the account',
+      ],
+      [
         'id' => 'prune-the-account',
         'title' => 'Prune the account',
       ],
@@ -20,11 +24,15 @@
     <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2">
       <div>
         <p class="mb-2">These endpoints help users manage account lifecycle tasks.</p>
-        <p class="mb-2">You can prune journals while keeping login access, or permanently delete the account.</p>
+        <p class="mb-2">You can schedule automatic account deletion, prune journals while keeping login access, or permanently delete the account.</p>
       </div>
       <div>
         <x-marketing.docs.code title="Endpoints">
           <div class="flex flex-col gap-y-2">
+            <a href="#auto-delete-the-account">
+              <span class="text-orange-500">PUT</span>
+              /api/settings/security/auto-delete-account
+            </a>
             <a href="#prune-the-account">
               <span class="text-orange-500">PUT</span>
               /api/settings/prune
@@ -34,6 +42,47 @@
               /api/settings/account
             </a>
           </div>
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/settings/security/auto-delete-account -->
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="auto-delete-the-account" title="Auto delete the account" />
+        <p class="mb-10">This endpoint toggles automatic account deletion for the authenticated user.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <p class="text-gray-500">This endpoint does not have any parameters.</p>
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute required name="auto_delete_account" type="string" description="Set to 'yes' to enable automatic deletion, or 'no' to disable it." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <x-marketing.docs.attribute name="message" type="string" description="Confirmation message for the auto-delete change." />
+          <x-marketing.docs.attribute name="status" type="integer" description="HTTP status code." />
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/settings/security/auto-delete-account" verb="PUT" verbClass="text-yellow-700">
+          <div>{</div>
+          <div class="pl-4">
+            <span class="text-lime-700">"message"</span>
+            :
+            <span class="text-amber-700">"Changes saved"</span>
+            ,
+          </div>
+          <div class="pl-4">
+            <span class="text-lime-700">"status"</span>
+            :
+            <span class="text-indigo-700">200</span>
+          </div>
+          <div>}</div>
         </x-marketing.docs.code>
       </div>
     </div>

--- a/resources/views/marketing/docs/api/account/account.blade.php
+++ b/resources/views/marketing/docs/api/account/account.blade.php
@@ -59,7 +59,7 @@
 
         <!-- query parameters -->
         <x-marketing.docs.query-parameters>
-          <x-marketing.docs.attribute required name="auto_delete_account" type="string" description="Set to 'yes' to enable automatic deletion, or 'no' to disable it." />
+          <x-marketing.docs.attribute required name="auto_delete_account" type="boolean" description="Set to true to enable automatic deletion, or false to disable it." />
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\Journals;
 use App\Http\Controllers\Api\Settings;
 use App\Http\Controllers\Api\Settings\Account\DestroyAccountController;
 use App\Http\Controllers\Api\Settings\Account\PruneAccountController;
+use App\Http\Controllers\Api\Settings\Security\AutoDeleteAccountController;
 use Illuminate\Support\Facades\Route;
 
 Route::name('api.')->group(function (): void {
@@ -49,6 +50,7 @@ Route::name('api.')->group(function (): void {
 
         // settings - account
         Route::put('settings/prune', [PruneAccountController::class, 'update'])->name('settings.account.prune');
+        Route::put('settings/security/auto-delete-account', [AutoDeleteAccountController::class, 'update'])->name('settings.security.auto-delete.update');
         Route::delete('settings/account', [DestroyAccountController::class, 'destroy'])->name('settings.account.destroy');
     });
 });

--- a/tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Settings\Security;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AutoDeleteAccountControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_auto_delete_account_setting_to_true(): void
+    {
+        $user = User::factory()->create([
+            'auto_delete_account' => false,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/settings/security/auto-delete-account', [
+            'auto_delete_account' => 'yes',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => trans('Changes saved'),
+            'status' => 200,
+        ]);
+
+        $this->assertTrue($user->fresh()->auto_delete_account);
+    }
+
+    #[Test]
+    public function it_updates_auto_delete_account_setting_to_false(): void
+    {
+        $user = User::factory()->create([
+            'auto_delete_account' => true,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/settings/security/auto-delete-account', [
+            'auto_delete_account' => 'no',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => trans('Changes saved'),
+            'status' => 200,
+        ]);
+
+        $this->assertFalse($user->fresh()->auto_delete_account);
+    }
+}

--- a/tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php
@@ -24,7 +24,7 @@ final class AutoDeleteAccountControllerTest extends TestCase
         Sanctum::actingAs($user);
 
         $response = $this->json('PUT', '/api/settings/security/auto-delete-account', [
-            'auto_delete_account' => 'yes',
+            'auto_delete_account' => true,
         ]);
 
         $response->assertStatus(200);
@@ -46,7 +46,7 @@ final class AutoDeleteAccountControllerTest extends TestCase
         Sanctum::actingAs($user);
 
         $response = $this->json('PUT', '/api/settings/security/auto-delete-account', [
-            'auto_delete_account' => 'no',
+            'auto_delete_account' => false,
         ]);
 
         $response->assertStatus(200);

--- a/tests/Feature/Controllers/App/Settings/Security/AutoDeleteAccountControllerTest.php
+++ b/tests/Feature/Controllers/App/Settings/Security/AutoDeleteAccountControllerTest.php
@@ -23,7 +23,7 @@ final class AutoDeleteAccountControllerTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->put(route('settings.security.auto-delete.update'), [
-            'auto_delete_account' => 'yes',
+            'auto_delete_account' => true,
         ]);
 
         $response->assertRedirect(route('settings.security.index'));
@@ -42,7 +42,7 @@ final class AutoDeleteAccountControllerTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->put(route('settings.security.auto-delete.update'), [
-            'auto_delete_account' => 'no',
+            'auto_delete_account' => false,
         ]);
 
         $response->assertRedirect(route('settings.security.index'));


### PR DESCRIPTION
### Motivation
- Provide an API equivalent to the existing web `AutoDeleteAccountController` so clients can toggle automatic account deletion via the API.
- Keep API behavior consistent with the web settings flow and provide a documented, test-covered surface for the feature.

### Description
- Add `App\Http\Controllers\Api\Settings\Security\AutoDeleteAccountController` which validates `auto_delete_account` and updates the authenticated user's flag, returning a JSON success response.
- Register a new route `PUT /api/settings/security/auto-delete-account` in `routes/api.php` named `settings.security.auto-delete.update`.
- Add a PHPUnit feature test at `tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php` covering enabling and disabling the setting with `Sanctum::actingAs`.
- Document the endpoint in the marketing docs (`resources/views/marketing/docs/api/account/account.blade.php`) and add a Bruno collection entry (`docs/bruno/JournalOS/Auto Delete Account.bru`).

### Testing
- Created a feature test `tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php` and it asserts JSON success and persistence of the `auto_delete_account` flag (test file added but not executed successfully here).
- Attempted to run `vendor/bin/pint --dirty` which failed because `vendor/bin/pint` is not available in the current environment (dependencies missing).
- Attempted to run `php artisan test tests/Feature/Controllers/Api/Settings/Security/AutoDeleteAccountControllerTest.php` which failed due to missing `vendor/autoload.php` (dependencies not installed), so tests could not be executed in this environment.
- All added code follows existing API controller patterns and uses the existing `ApiResponses` trait for consistent JSON responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952880e935c8320a3637824c90fdf64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **New API endpoint**: Added `PUT /api/settings/security/auto-delete-account` to toggle automatic account deletion for authenticated users
- **Validation**: Auto-delete account setting is now validated as a boolean value
- **Response**: Endpoint returns JSON response with "Changes saved" message and 200 status code
- **Documentation**: Endpoint documented in API documentation with parameters, response attributes, and example usage
- **API testing**: Added Bruno collection entry for testing the new endpoint
- **Test coverage**: Includes feature tests validating the toggle functionality for both enabling and disabling automatic account deletion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->