### PR TITLE
Add API controller for deleting journals and update routes, tests and docs

### DIFF
--- a/app/Http/Controllers/Api/Journals/DestroyJournalController.php
+++ b/app/Http/Controllers/Api/Journals/DestroyJournalController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals;
+
+use App\Actions\DestroyJournal;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+
+final class DestroyJournalController extends Controller
+{
+    public function destroy(Request $request): Response
+    {
+        $journal = $request->attributes->get('journal');
+
+        new DestroyJournal(
+            user: Auth::user(),
+            journal: $journal,
+        )->execute();
+
+        return response()->noContent(204);
+    }
+}

--- a/app/Http/Controllers/Api/Journals/JournalController.php
+++ b/app/Http/Controllers/Api/Journals/JournalController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\Journals;
 
 use App\Actions\CreateJournal;
-use App\Actions\DestroyJournal;
 use App\Actions\RenameJournal;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalResource;
@@ -13,7 +12,6 @@ use App\Traits\ApiResponses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 final class JournalController extends Controller
@@ -71,15 +69,4 @@ final class JournalController extends Controller
             ->setStatusCode(200);
     }
 
-    public function destroy(Request $request): Response
-    {
-        $journal = $request->attributes->get('journal');
-
-        new DestroyJournal(
-            user: Auth::user(),
-            journal: $journal,
-        )->execute();
-
-        return response()->noContent(204);
-    }
 }

--- a/docs/bruno/JournalOS/Journals/Delete journal.bru
+++ b/docs/bruno/JournalOS/Journals/Delete journal.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{URL}}/journals/11
+  url: {{URL}}/journals/1
   body: json
   auth: inherit
 }

--- a/resources/views/marketing/docs/api/journals/journals.blade.php
+++ b/resources/views/marketing/docs/api/journals/journals.blade.php
@@ -23,6 +23,10 @@
         'id' => 'update-a-journal',
         'title' => 'Update a journal',
       ],
+      [
+        'id' => 'delete-a-journal',
+        'title' => 'Delete a journal',
+      ],
     ]" />
 
     <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2">
@@ -47,6 +51,12 @@
             <a href="#create-a-journal">
               <span class="text-green-700">POST</span>
               /api/journals
+            </a>
+          </div>
+          <div class="flex flex-col gap-y-2">
+            <a href="#delete-a-journal">
+              <span class="text-red-700">DELETE</span>
+              /api/journals/{id}
             </a>
           </div>
         </x-marketing.docs.code>
@@ -168,7 +178,7 @@
     </div>
 
     <!-- PUT /api/journals -->
-    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2">
       <div>
         <x-marketing.docs.h2 id="update-a-journal" title="Update a journal" />
         <p class="mb-10">This endpoint updates the name of the journal. It will return the journal in the response. The avatar is automatically generated.</p>
@@ -200,6 +210,34 @@
       <div>
         <x-marketing.docs.code title="/api/journals/{id}" verb="PUT" verbClass="text-green-700">
           @include('marketing.docs.api.partials.journal-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- DELETE /api/journals/{id} -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="delete-a-journal" title="Delete a journal" />
+        <p class="mb-10">This endpoint deletes a journal owned by the authenticated user.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal to delete." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <p class="text-gray-500">No query parameters are available for this endpoint.</p>
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <p class="text-gray-500">No response attributes are available for this endpoint.</p>
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}" verb="DELETE" verbClass="text-red-700">
+          <div>No response body</div>
         </x-marketing.docs.code>
       </div>
     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,7 +34,7 @@ Route::name('api.')->group(function (): void {
 
             // settings
             Route::put('journals/{id}', [Journals\JournalController::class, 'update'])->name('journal.update');
-            Route::delete('journals/{id}', [Journals\JournalController::class, 'destroy'])->name('journal.destroy');
+            Route::delete('journals/{id}', [Journals\DestroyJournalController::class, 'destroy'])->name('journal.destroy');
         });
 
         // settings

--- a/tests/Feature/Controllers/Api/Journals/DestroyJournalControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/DestroyJournalControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals;
+
+use App\Models\Journal;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DestroyJournalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_can_delete_a_journal(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('DELETE', '/api/journals/' . $journal->id);
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('journals', [
+            'id' => $journal->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_returns_not_found_when_deleting_a_journal_the_user_does_not_own(): void
+    {
+        $user = User::factory()->create();
+        $otherJournal = Journal::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('DELETE', '/api/journals/' . $otherJournal->id);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/Api/Journals/JournalControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalControllerTest.php
@@ -205,36 +205,4 @@ final class JournalControllerTest extends TestCase
             ],
         ]);
     }
-
-    #[Test]
-    public function it_can_delete_a_journal(): void
-    {
-        $user = User::factory()->create();
-        $journal = Journal::factory()->create([
-            'user_id' => $user->id,
-        ]);
-
-        Sanctum::actingAs($user);
-
-        $response = $this->json('DELETE', '/api/journals/' . $journal->id);
-
-        $response->assertNoContent();
-
-        $this->assertDatabaseMissing('journals', [
-            'id' => $journal->id,
-        ]);
-    }
-
-    #[Test]
-    public function it_returns_not_found_when_deleting_a_journal_the_user_does_not_own(): void
-    {
-        $user = User::factory()->create();
-        $otherJournal = Journal::factory()->create();
-
-        Sanctum::actingAs($user);
-
-        $response = $this->json('DELETE', '/api/journals/' . $otherJournal->id);
-
-        $response->assertStatus(404);
-    }
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated API endpoint/controller for deleting a journal to keep the `JournalController` focused on list/show/create/update responsibilities.
- Reuse the existing `DestroyJournal` action so the deletion logic stays in one place and is consistent between web and API flows.
- Split test coverage so deletion is covered by a focused test class to make tests clearer and easier to maintain.
- Update Bruno and marketing documentation to reflect the new `DELETE /api/journals/{id}` API endpoint.

### Description
- Added `app/Http/Controllers/Api/Journals/DestroyJournalController.php` which calls the existing `DestroyJournal` action and returns `response()->noContent(204)`.
- Removed the `destroy` method from `app/Http/Controllers/Api/Journals/JournalController.php` and wired the route in `routes/api.php` to `Journals\DestroyJournalController::destroy`.
- Created a new test `tests/Feature/Controllers/Api/Journals/DestroyJournalControllerTest.php` and removed the delete-related tests from `tests/Feature/Controllers/Api/Journals/JournalControllerTest.php`.
- Updated Bruno docs `docs/bruno/JournalOS/Journals/Delete journal.bru` and the marketing docs view `resources/views/marketing/docs/api/journals/journals.blade.php` to include the delete endpoint and its documentation.

### Testing
- Attempted to run formatter `vendor/bin/pint --dirty`, but it failed because `vendor/bin/pint` is not available due to Composer install not completing in this environment (network/GitHub access errors).
- Attempted to run the new test with `php artisan test tests/Feature/Controllers/Api/Journals/DestroyJournalControllerTest.php`, but it failed because `vendor/autoload.php` is missing (Composer install could not complete).
- No test ran successfully in this environment due to the dependency installation issue, but the test files were added and follow the repository's existing test patterns and conventions.
- The code was formatted to match existing project structure and placement, but `vendor/bin/pint` could not be executed here to validate formatting automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529a4043f883208c6d05c7ae0e35d1)