### PR TITLE
fix: fix blade slot closing tags in app views

### DIFF
--- a/resources/views/app/claim.blade.php
+++ b/resources/views/app/claim.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Claim your account') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
@@ -14,7 +14,7 @@
         <!-- Left: Form -->
         <div>
           <x-box>
-            <x-slot:title>{{ __('Claim your account and make it permanent') }}</x-slot>
+            <x-slot:title>{{ __('Claim your account and make it permanent') }}</x-slot:title>
 
             <x-form method="post" :action="route('claim.store')" class="space-y-4">
               <!-- First and Last Name -->

--- a/resources/views/app/journal/create.blade.php
+++ b/resources/views/app/journal/create.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Create journal') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
@@ -11,7 +11,7 @@
   <div class="px-6 pt-12">
     <div class="mx-auto w-full max-w-xl items-start justify-center">
       <x-box>
-        <x-slot:title>{{ __('Create journal') }}</x-slot>
+        <x-slot:title>{{ __('Create journal') }}</x-slot:title>
 
         <x-form method="post" :action="route('journal.store')" class="space-y-4">
           <x-input id="journal_name" name="journal_name" :label="__('Name')" :help="__('The name can only contain letters, numbers, spaces, hyphens, and underscores.')" :error="$errors->get('journal_name')" required placeholder="Dunder Mifflin" autofocus />

--- a/resources/views/app/journal/entry/partials/sleep.blade.php
+++ b/resources/views/app/journal/entry/partials/sleep.blade.php
@@ -1,6 +1,6 @@
 <x-module>
-  <x-slot:title>{{ __('Sleep tracking') }}</x-slot>
-  <x-slot:emoji>🌖</x-slot>
+  <x-slot:title>{{ __('Sleep tracking') }}</x-slot:title>
+  <x-slot:emoji>🌖</x-slot:emoji>
   <x-slot:action>
     <div id="reset">
       @if ($module['display_reset'])
@@ -11,7 +11,7 @@
         </x-form>
       @endif
     </div>
-  </x-slot>
+  </x-slot:action>
 
   <div id="sleep-container" class="space-y-4">
     <div class="space-y-2">

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Journal') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
@@ -38,7 +38,7 @@
       @include('app.journal.entry.partials.sleep', ['module' => $modules['sleep']])
 
       <x-module>
-        <x-slot:title>{{ __('Claim your account and make it permanent') }}</x-slot>
+        <x-slot:title>{{ __('Claim your account and make it permanent') }}</x-slot:title>
         sdflsjf
       </x-module>
     </div>

--- a/resources/views/app/journal/index.blade.php
+++ b/resources/views/app/journal/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Dashboard') }}
-  </x-slot>
+  </x-slot:title>
 
   <div class="px-6 pt-6">
     <div class="mx-auto w-full max-w-4xl items-start justify-center">
@@ -11,7 +11,7 @@
         <x-button.secondary href="{{ route('journal.create') }}" turbo="true">
           <x-slot:icon>
             <x-phosphor-plus-bold class="size-4" />
-          </x-slot>
+          </x-slot:icon>
           {{ __('New journal') }}
         </x-button.secondary>
       </div>

--- a/resources/views/app/journal/settings/partials/delete.blade.php
+++ b/resources/views/app/journal/settings/partials/delete.blade.php
@@ -1,11 +1,11 @@
 <x-box>
   <x-slot:title>
     {{ __('Delete journal') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-slot:description>
     {{ __('This will delete the journal and all the related journal entries.') }}
-  </x-slot>
+  </x-slot:description>
 
   <x-form onsubmit="return confirm('Are you absolutely sure? This action cannot be undone.');" action="{{ route('journal.destroy', ['slug' => $journal->slug]) }}" method="delete">
     <x-button.danger type="submit" class="text-sm">

--- a/resources/views/app/journal/settings/partials/rename.blade.php
+++ b/resources/views/app/journal/settings/partials/rename.blade.php
@@ -1,5 +1,5 @@
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Rename journal') }}</x-slot>
+  <x-slot:title>{{ __('Rename journal') }}</x-slot:title>
 
   <x-form method="put" action="{{ route('journal.update', ['slug' => $journal->slug]) }}">
     <div class="grid grid-cols-3 items-center rounded-t-lg border-b border-gray-200 p-3 hover:bg-blue-50">

--- a/resources/views/app/journal/settings/show.blade.php
+++ b/resources/views/app/journal/settings/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Journal settings') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],

--- a/resources/views/app/settings/account/index.blade.php
+++ b/resources/views/app/settings/account/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Account administration') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],

--- a/resources/views/app/settings/account/partials/delete-account.blade.php
+++ b/resources/views/app/settings/account/partials/delete-account.blade.php
@@ -1,11 +1,11 @@
 <x-box>
   <x-slot:title>
     {{ __('Delete your account') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-slot:description>
     {{ __('Your account and all data will be deleted immediately and cannot be restored. This is irreversible. Please be certain.') }}
-  </x-slot>
+  </x-slot:description>
 
   <form action="{{ route('settings.account.destroy') }}" method="post" x-data="{
     feedback: '',

--- a/resources/views/app/settings/account/partials/prune-account.blade.php
+++ b/resources/views/app/settings/account/partials/prune-account.blade.php
@@ -1,11 +1,11 @@
 <x-box>
   <x-slot:title>
     {{ __('Prune your account') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-slot:description>
     {{ __('Delete all journals and related data from your account. This lets you start over with a new account.') }}
-  </x-slot>
+  </x-slot:description>
 
   <x-form onsubmit="return confirm('Are you absolutely sure? This action cannot be undone.');" action="{{ route('settings.account.prune') }}" method="put">
     <x-button.secondary type="submit" class="mr-2 text-sm">

--- a/resources/views/app/settings/emails/index.blade.php
+++ b/resources/views/app/settings/emails/index.blade.php
@@ -7,7 +7,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Emails sent') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
@@ -24,7 +24,7 @@
     <section class="p-4 sm:p-8">
       <div class="mx-auto max-w-4xl sm:px-0">
         <x-box id="emails-sent-container" x-merge="append" padding="p-0">
-          <x-slot:title>{{ __('Emails sent') }}</x-slot>
+          <x-slot:title>{{ __('Emails sent') }}</x-slot:title>
           <!-- last actions -->
           @foreach ($emails as $email)
             <div x-data="{ open: false, isLast: {{ $loop->last ? 'true' : 'false' }} }">

--- a/resources/views/app/settings/logs/index.blade.php
+++ b/resources/views/app/settings/logs/index.blade.php
@@ -7,7 +7,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Profile') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
@@ -24,7 +24,7 @@
     <section class="p-4 sm:p-8">
       <div class="mx-auto max-w-4xl sm:px-0">
         <x-box id="logs-container" x-merge="append" padding="p-0">
-          <x-slot:title>{{ __('Logs') }}</x-slot>
+          <x-slot:title>{{ __('Logs') }}</x-slot:title>
           <!-- last actions -->
           @foreach ($logs as $log)
             <div class="flex items-center justify-between border-b border-gray-200 p-3 text-sm first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-blue-50">

--- a/resources/views/app/settings/profile/index.blade.php
+++ b/resources/views/app/settings/profile/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Profile') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],

--- a/resources/views/app/settings/profile/partials/details.blade.php
+++ b/resources/views/app/settings/profile/partials/details.blade.php
@@ -5,7 +5,7 @@
 ?>
 
 <x-box>
-  <x-slot:title>{{ __('Details') }}</x-slot>
+  <x-slot:title>{{ __('Details') }}</x-slot:title>
 
   <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
     <div class="space-y-2">

--- a/resources/views/app/settings/profile/partials/emails.blade.php
+++ b/resources/views/app/settings/profile/partials/emails.blade.php
@@ -1,5 +1,5 @@
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Emails sent') }}</x-slot>
+  <x-slot:title>{{ __('Emails sent') }}</x-slot:title>
 
   @forelse ($emails as $emailSent)
     <div x-data="{ open: false, isLast: {{ $loop->last ? 'true' : 'false' }} }">

--- a/resources/views/app/settings/profile/partials/logs.blade.php
+++ b/resources/views/app/settings/profile/partials/logs.blade.php
@@ -1,8 +1,8 @@
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Logs') }}</x-slot>
+  <x-slot:title>{{ __('Logs') }}</x-slot:title>
   <x-slot:description>
     <p>{{ __('All actions performed on your account are logged here.') }}</p>
-  </x-slot>
+  </x-slot:description>
 
   <!-- last actions -->
   @foreach ($logs as $log)

--- a/resources/views/app/settings/security/index.blade.php
+++ b/resources/views/app/settings/security/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
   <x-slot:title>
     {{ __('Security and access') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],

--- a/resources/views/app/settings/security/partials/2fa/preferred-method.blade.php
+++ b/resources/views/app/settings/security/partials/2fa/preferred-method.blade.php
@@ -1,9 +1,9 @@
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Two-factor authentication') }}</x-slot>
+  <x-slot:title>{{ __('Two-factor authentication') }}</x-slot:title>
   <x-slot:description>
     <p>{{ __('Two-factor authentication adds an additional layer of security to your account by requiring more than just a password to sign in.') }}</p>
     <p>{{ __('Set your preferred method to use for two-factor authentication when signing into the application.') }}</p>
-  </x-slot>
+  </x-slot:description>
 
   <x-form method="put" x-target="preferred-method-form notifications" x-target.back="preferred-method-form" id="preferred-method-form" :action="route('settings.security.2fa.update')">
     <!-- preferred methods -->

--- a/resources/views/app/settings/security/partials/api/index.blade.php
+++ b/resources/views/app/settings/security/partials/api/index.blade.php
@@ -5,11 +5,11 @@
 ?>
 
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Personal API Keys') }}</x-slot>
+  <x-slot:title>{{ __('Personal API Keys') }}</x-slot:title>
   <x-slot:description>
     <p>{{ __('API keys are like secret passwords that allow other tools or apps to connect securely to your account.') }}</p>
     <p>{{ __('Each API key is unique to you. Treat them like private passwords—don’t share them with anyone you don’t trust.') }}</p>
-  </x-slot>
+  </x-slot:description>
 
   <div id="api-key-notification">
     @if (session('apiKey'))

--- a/resources/views/app/settings/security/partials/auto-delete.blade.php
+++ b/resources/views/app/settings/security/partials/auto-delete.blade.php
@@ -1,11 +1,11 @@
 <x-box padding="p-0">
   <x-slot:title>
     {{ __('Auto delete account') }}
-  </x-slot>
+  </x-slot:title>
 
   <x-slot:description>
     {{ __('Automatically delete the account and all the data after 6 months of inactivity. Please be certain.') }}
-  </x-slot>
+  </x-slot:description>
 
   <x-form id="auto-delete-account-form" x-target="auto-delete-account-form" x-target.back="auto-delete-account-form" action="{{ route('settings.security.auto-delete.update') }}" method="put">
     <div class="grid grid-cols-3 items-center rounded-t-lg p-3 last:rounded-b-lg hover:bg-blue-50">

--- a/resources/views/app/settings/security/partials/password.blade.php
+++ b/resources/views/app/settings/security/partials/password.blade.php
@@ -5,7 +5,7 @@
 ?>
 
 <x-box padding="p-0">
-  <x-slot:title>{{ __('Change password') }}</x-slot>
+  <x-slot:title>{{ __('Change password') }}</x-slot:title>
 
   <x-form method="put" action="{{ route('settings.password.update') }}">
     <!-- current password -->


### PR DESCRIPTION
### Motivation
- Close shorthand Blade slot tags with their matching named closing tags to ensure template correctness and avoid ambiguity.
- Prevent Blade parsing/rendering issues caused by unnamed `</x-slot>` tags in component usage.

### Description
- Replaced occurrences of `</x-slot>` with matching `</x-slot:<name>>` in many files under `resources/views/app` so each opening `<x-slot:<name>>` has a named closing tag.
- Changes span 22 files in the `resources/views/app` tree and were applied programmatically.
- A small Python script was used to locate `<x-slot:<name>>` openings and rewrite the corresponding closing tags to the named form.
- All modifications were committed to the repository.

### Testing
- Ran `php artisan test tests/Feature/Controllers/App/Journals`, which failed due to missing `vendor/autoload.php` (vendor dependencies not installed).
- Ran `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` was not available (vendor dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529b2ff04483208507cfe3292f57bf)