### PR TITLE
docs: add marketing docs for delete journal

### DIFF
--- a/docs/bruno/JournalOS/Journals/Delete journal.bru
+++ b/docs/bruno/JournalOS/Journals/Delete journal.bru
@@ -6,6 +6,6 @@ meta {
 
 delete {
   url: {{URL}}/journals/11
-  body: json
+  body: none
   auth: inherit
 }

--- a/resources/views/marketing/docs/api/journals/journals.blade.php
+++ b/resources/views/marketing/docs/api/journals/journals.blade.php
@@ -23,6 +23,10 @@
         'id' => 'update-a-journal',
         'title' => 'Update a journal',
       ],
+      [
+        'id' => 'delete-a-journal',
+        'title' => 'Delete a journal',
+      ],
     ]" />
 
     <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2">
@@ -47,6 +51,18 @@
             <a href="#create-a-journal">
               <span class="text-green-700">POST</span>
               /api/journals
+            </a>
+          </div>
+          <div class="flex flex-col gap-y-2">
+            <a href="#update-a-journal">
+              <span class="text-green-700">PUT</span>
+              /api/journals/{id}
+            </a>
+          </div>
+          <div class="flex flex-col gap-y-2">
+            <a href="#delete-a-journal">
+              <span class="text-red-700">DELETE</span>
+              /api/journals/{id}
             </a>
           </div>
         </x-marketing.docs.code>
@@ -200,6 +216,34 @@
       <div>
         <x-marketing.docs.code title="/api/journals/{id}" verb="PUT" verbClass="text-green-700">
           @include('marketing.docs.api.partials.journal-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- DELETE /api/journals/{id} -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="delete-a-journal" title="Delete a journal" />
+        <p class="mb-10">This endpoint deletes a journal. It will return a success message in the response.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <p class="text-gray-500">No query parameters are available for this endpoint.</p>
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <p class="text-gray-500">No response attributes are available for this endpoint.</p>
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}" verb="DELETE" verbClass="text-red-700">
+          <div>No response body</div>
         </x-marketing.docs.code>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Ensure the Bruno delete example reflects that DELETE requests have no payload by changing the Bruno request `body` to `none`.
- Expose the DELETE `/api/journals/{id}` endpoint in the marketing documentation so the API docs are complete and consistent.
- Make it explicit to consumers that delete responses have no response body.

### Description
- Updated `docs/bruno/JournalOS/Journals/Delete journal.bru` to set `body: none` for the delete request.
- Updated `resources/views/marketing/docs/api/journals/journals.blade.php` to add a TOC entry and endpoint link for `DELETE /api/journals/{id}`, and added a new DELETE section with URL parameter and a note that there is no response body.
- Committed the updated marketing view file.

### Testing
- Ran `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` is not available in this environment.
- Ran `php artisan test tests/Feature/Controllers/Api/Journals/JournalControllerTest.php`, which failed due to missing `vendor/autoload.php` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529cd1907c832087ff2334e7251afb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated Bruno delete example for DELETE /api/journals to set request body to `none`, accurately reflecting that DELETE requests have no payload
- Added DELETE /api/journals/{id} endpoint to marketing API documentation with URL parameter details and endpoint reference
- Documented DELETE endpoint response behavior, explicitly noting there is no response body

<!-- end of auto-generated comment: release notes by coderabbit.ai -->