### PR TITLE
test: add tests for marketing controllers

### DIFF
--- a/tests/Feature/Controllers/Marketing/AccountControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/AccountControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AccountControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_account_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.account', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.account.account');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.account.prune';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/ApiIntroductionControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/ApiIntroductionControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ApiIntroductionControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_api_introduction_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.index', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.introduction');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.introduction';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/ApiManagementControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/ApiManagementControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ApiManagementControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_api_management_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.account.api-management', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.account.api-management');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.account.api-management';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/AuthenticationControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/AuthenticationControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AuthenticationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_authentication_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.authentication', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.authentication');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.authentication';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/DocControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/DocControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DocControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_docs_index(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.index', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.introduction');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.introduction';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/EmailSentControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/EmailSentControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EmailSentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_email_sent_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.account.emails', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.account.emails');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.account.emails';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/HierarchicalStructureControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/HierarchicalStructureControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HierarchicalStructureControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_hierarchical_structure_concepts_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.concepts.hierarchical-structure', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.concepts.hierarchy-structure');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.concepts.hierarchy-structure';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/JournalControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/JournalControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class JournalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_journal_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.journals', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.journals.journals');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.journals.journals';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/LogControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/LogControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class LogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_log_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.account.logs', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.account.logs');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.account.logs';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/PermissionControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/PermissionControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PermissionControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_permissions_concepts_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.concepts.permissions', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.concepts.permissions');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.concepts.permissions';
+        });
+    }
+}

--- a/tests/Feature/Controllers/Marketing/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/ProfileControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ProfileControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_profile_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.account.profile', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.account.profile');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.account.profile';
+        });
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure all Marketing docs controllers render their pages correctly and that page visits are recorded.
- Verify the `RecordMarketingPageVisit` job is dispatched for each marketing docs route.

### Description

- Add 11 new feature tests under `tests/Feature/Controllers/Marketing` covering each Marketing docs controller.
- Each test uses `RefreshDatabase`, fakes the queue with `Queue::fake()`, performs a `GET` to the named route, and asserts the response is OK and the expected view is returned.
- Each test asserts the `RecordMarketingPageVisit` job was queued on the `low` queue and that the job's `viewName` matches the expected view.
- Tests use PHPUnit `#[Test]` attributes and are named to describe the page they validate.

### Testing

- Attempted to run `vendor/bin/pint --dirty`, but it could not run because the `vendor/` directory is missing in this environment (failed).
- Attempted to run `php artisan test tests/Feature/Controllers/Marketing/DocControllerTest.php`, but it could not run because the `vendor/` directory is missing (failed).
- Attempted `composer install` to populate `vendor/`, but it prompted for GitHub authentication in this environment and did not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529eb949e48320b48f85e6c7e9d5b3)