### PR TITLE
feat: api endpoint to retrieve a single journal entry by date

### DIFF
--- a/app/Http/Controllers/Api/Journals/JournalEntryController.php
+++ b/app/Http/Controllers/Api/Journals/JournalEntryController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class JournalEntryController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $journalEntry = $request->attributes->get('journal_entry');
+
+        return new JournalEntryResource($journalEntry)
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/app/Http/Middleware/CheckJournalEntryAPI.php
+++ b/app/Http/Middleware/CheckJournalEntryAPI.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Actions\CreateOrRetrieveJournalEntry;
+use Closure;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CheckJournalEntryAPI
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $day = (int) $request->route()->parameter('day');
+        $month = (int) $request->route()->parameter('month');
+        $year = (int) $request->route()->parameter('year');
+
+        if (! checkdate($month, $day, $year)) {
+            abort(404);
+        }
+
+        try {
+            $journal = $request->attributes->get('journal');
+
+            $entry = new CreateOrRetrieveJournalEntry(
+                user: Auth::user(),
+                journal: $journal,
+                day: $day,
+                month: $month,
+                year: $year,
+            )->execute();
+        } catch (ModelNotFoundException) {
+            abort(404);
+        }
+
+        $request->attributes->add(['journal_entry' => $entry]);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Resources/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntryResource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\JournalEntry;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin JournalEntry
+ */
+final class JournalEntryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'type' => 'journal_entry',
+            'id' => (string) $this->id,
+            'attributes' => [
+                'journal_id' => $this->journal_id,
+                'day' => $this->day,
+                'month' => $this->month,
+                'year' => $this->year,
+                'bedtime' => $this->bedtime,
+                'wake_up_time' => $this->wake_up_time,
+                'sleep_duration_in_minutes' => $this->sleep_duration_in_minutes,
+                'modules' => [
+                    'sleep' => [
+                        'bedtime' => $this->bedtime,
+                        'wake_up_time' => $this->wake_up_time,
+                        'sleep_duration_in_minutes' => $this->sleep_duration_in_minutes,
+                    ],
+                ],
+                'created_at' => $this->created_at->timestamp,
+                'updated_at' => $this->updated_at?->timestamp,
+            ],
+            'links' => [
+                'self' => route('api.journal.entry.show', [
+                    'id' => $this->journal_id,
+                    'year' => $this->year,
+                    'month' => $this->month,
+                    'day' => $this->day,
+                ]),
+            ],
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,7 @@ use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\CheckJournal;
 use App\Http\Middleware\CheckJournalAPI;
 use App\Http\Middleware\CheckJournalEntry;
+use App\Http\Middleware\CheckJournalEntryAPI;
 use App\Http\Middleware\CheckSubscription;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -25,6 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'journal' => CheckJournal::class,
             'journal.api' => CheckJournalAPI::class,
             'journal.entry' => CheckJournalEntry::class,
+            'journal.entry.api' => CheckJournalEntryAPI::class,
             'instance.admin' => CheckInstanceAdministrator::class,
             'subscription' => CheckSubscription::class,
         ]);

--- a/docs/bruno/JournalOS/Entries/Get entry.bru
+++ b/docs/bruno/JournalOS/Entries/Get entry.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get entry
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{URL}}/journals/1/2025/12/29
+  body: none
+  auth: inherit
+}

--- a/docs/bruno/JournalOS/Entries/folder.bru
+++ b/docs/bruno/JournalOS/Entries/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Entries
+  seq: 6
+}
+
+auth {
+  mode: inherit
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Api\Auth\LoginController;
 use App\Http\Controllers\Api\HealthController;
 use App\Http\Controllers\Api\Journals;
+use App\Http\Controllers\Api\Journals\JournalEntryController;
 use App\Http\Controllers\Api\Settings;
 use App\Http\Controllers\Api\Settings\Account\DestroyAccountController;
 use App\Http\Controllers\Api\Settings\Account\PruneAccountController;
@@ -31,6 +32,14 @@ Route::name('api.')->group(function (): void {
 
         Route::middleware(['journal.api'])->group(function (): void {
             Route::get('journals/{id}', [Journals\JournalController::class, 'show'])->name('journal.show');
+
+            Route::middleware(['journal.entry.api'])->group(function (): void {
+                Route::get('journals/{id}/{year}/{month}/{day}', [JournalEntryController::class, 'show'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.show');
+            });
 
             // settings
             Route::put('journals/{id}', [Journals\JournalController::class, 'update'])->name('journal.update');

--- a/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class JournalEntryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $singleJsonStructure = [
+        'data' => [
+            'type',
+            'id',
+            'attributes' => [
+                'journal_id',
+                'day',
+                'month',
+                'year',
+                'bedtime',
+                'wake_up_time',
+                'sleep_duration_in_minutes',
+                'modules' => [
+                    'sleep' => [
+                        'bedtime',
+                        'wake_up_time',
+                        'sleep_duration_in_minutes',
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+            'links' => [
+                'self',
+            ],
+        ],
+    ];
+
+    #[Test]
+    public function it_can_show_a_journal_entry_for_a_specific_day(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 12,
+            'month' => 4,
+            'year' => 2025,
+            'bedtime' => '22:30',
+            'wake_up_time' => '06:45',
+            'sleep_duration_in_minutes' => '495',
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('GET', '/api/journals/' . $journal->id . '/2025/4/12');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure($this->singleJsonStructure);
+        $response->assertJson([
+            'data' => [
+                'type' => 'journal_entry',
+                'id' => (string) $entry->id,
+                'attributes' => [
+                    'journal_id' => $journal->id,
+                    'day' => 12,
+                    'month' => 4,
+                    'year' => 2025,
+                    'bedtime' => '22:30',
+                    'wake_up_time' => '06:45',
+                    'sleep_duration_in_minutes' => '495',
+                    'modules' => [
+                        'sleep' => [
+                            'bedtime' => '22:30',
+                            'wake_up_time' => '06:45',
+                            'sleep_duration_in_minutes' => '495',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function it_returns_not_found_for_invalid_dates(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('GET', '/api/journals/' . $journal->id . '/2025/2/31');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
+    public function it_restricts_access_to_journal_entries_the_user_does_not_own(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('GET', '/api/journals/' . $journal->id . '/2025/4/12');
+
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an API to browse a journal entry for a single day using a date in the path rather than a list view. 
- Ensure the date components are validated and the journal ownership is checked once before controller handling. 
- Reuse the existing journal-entry creation/retrieval action so the API returns an entry whether it already exists or is newly created. 
- Include module data (currently sleep) in the API response so clients can render module sections.

### Description

- Added a new middleware `CheckJournalEntryAPI` that validates `year/month/day`, ensures the journal belongs to the authenticated user, and populates the request attribute `journal_entry` using `CreateOrRetrieveJournalEntry`.
- Registered the middleware alias `journal.entry.api` in `bootstrap/app.php` and guarded the new route with it.
- Added an API route `GET /api/journals/{id}/{year}/{month}/{day}` in `routes/api.php` constrained to numeric `year`, `month`, and `day` and named `api.journal.entry.show`.
- Implemented `App\Http\Controllers\Api\Journals\JournalEntryController::show` and `App\Http\Resources\JournalEntryResource` that return the entry attributes and a `modules.sleep` section containing the sleep fields.
- Added feature tests at `tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php` to verify successful retrieval, invalid-date handling, and access restrictions.

### Testing

- Ran `php artisan test tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php` and it failed to run in this environment due to missing dependencies (`vendor/autoload.php`).
- Attempted to run `vendor/bin/pint --dirty` to format changes and it was not available in the environment, so formatting could not be auto-applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a1116ca883208e68180b323ec47e)