### PR TITLE
fix: fix flaky wake-up time test dates

### DIFF
--- a/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -18,9 +18,15 @@ final class SleepWakeUpTimeControllerTest extends TestCase
     #[Test]
     public function it_updates_wake_up_time_and_redirects(): void
     {
+        $entryDate = [
+            'day' => 15,
+            'month' => 1,
+            'year' => 2024,
+        ];
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
         $entry = JournalEntry::factory()->for($journal)->create([
+            ...$entryDate,
             'bedtime' => '22:00',
             'wake_up_time' => '06:00',
         ]);
@@ -37,8 +43,13 @@ final class SleepWakeUpTimeControllerTest extends TestCase
     #[Test]
     public function it_redirects_guests_to_login(): void
     {
+        $entryDate = [
+            'day' => 15,
+            'month' => 1,
+            'year' => 2024,
+        ];
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create($entryDate);
 
         $response = $this->put(
             "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/wake_up_time",
@@ -51,9 +62,14 @@ final class SleepWakeUpTimeControllerTest extends TestCase
     #[Test]
     public function it_returns_404_for_unauthorized_entry(): void
     {
+        $entryDate = [
+            'day' => 15,
+            'month' => 1,
+            'year' => 2024,
+        ];
         $user = User::factory()->create();
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create($entryDate);
 
         $response = $this->actingAs($user)->put(
             "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/wake_up_time",

--- a/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -8,8 +8,8 @@ use App\Models\Journal;
 use App\Models\JournalEntry;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 final class SleepWakeUpTimeControllerTest extends TestCase
 {
@@ -18,41 +18,41 @@ final class SleepWakeUpTimeControllerTest extends TestCase
     #[Test]
     public function it_updates_wake_up_time_and_redirects(): void
     {
-        $entryDate = [
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
             'day' => 15,
             'month' => 1,
             'year' => 2024,
-        ];
-        $user = User::factory()->create();
-        $journal = Journal::factory()->for($user)->create();
-        $entry = JournalEntry::factory()->for($journal)->create([
-            ...$entryDate,
             'bedtime' => '22:00',
             'wake_up_time' => '06:00',
         ]);
 
         $response = $this->actingAs($user)->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/wake_up_time",
+            "/journals/{$journal->slug}/entries/2024/1/15/sleep/wake_up_time",
             ['wake_up_time' => '07:30'],
         );
 
-        $response->assertRedirectContains("/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}");
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/1/15");
         $response->assertSessionHas('status');
     }
 
     #[Test]
     public function it_redirects_guests_to_login(): void
     {
-        $entryDate = [
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
             'day' => 15,
             'month' => 1,
             'year' => 2024,
-        ];
-        $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create($entryDate);
+        ]);
 
         $response = $this->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/wake_up_time",
+            "/journals/{$journal->slug}/entries/2024/1/15/sleep/wake_up_time",
             ['wake_up_time' => '07:30'],
         );
 
@@ -69,10 +69,15 @@ final class SleepWakeUpTimeControllerTest extends TestCase
         ];
         $user = User::factory()->create();
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create($entryDate);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 15,
+            'month' => 1,
+            'year' => 2024,
+        ]);
 
         $response = $this->actingAs($user)->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/wake_up_time",
+            "/journals/{$journal->slug}/entries/2024/1/15/sleep/wake_up_time",
             ['wake_up_time' => '07:30'],
         );
 


### PR DESCRIPTION
### Motivation

- The wake-up time feature test was flaky because the factory-generated dates could be invalid and trigger a 404 during route/middleware date validation.  
- Make the test deterministic by using a fixed, valid journal entry date to eliminate randomness.  
- Keep the change confined to the test suite so production behavior is unchanged.

### Description

- Pinned the journal entry date to a deterministic value (`day: 15, month: 1, year: 2024`) in `tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php`.  
- Applied the fixed date to all three tests in that file and used the array spread (`...$entryDate`) when creating the `JournalEntry`.  
- No application code or routes were modified, only the test file was updated.

### Testing

- Attempted to run `vendor/bin/pint --dirty` but it failed due to missing vendor dependencies.  
- Attempted to run `php artisan test tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php` but it failed because `vendor/autoload.php` is not present in this environment.  
- The change is limited to tests and should remove the random 404 flakiness; please run the test file in CI or locally after installing dependencies to confirm passing results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a19ea21083208b334f9f7a2426af)