### PR TITLE
feat: api to manage sleep module

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,6 +6,7 @@
 - [ ] notion of denormalized data
 - [ ] display the number of entries on a month
 - [ ] display months containing entries
+- [ ] ability to reset an entire day
 
 Life
 - [x] Sleep
@@ -19,7 +20,7 @@ Life
 - [ ] Sexual activity (optional module)
 
 Work
-- [ ] Worked today
+- [x] Worked today
 - [ ] Work mode
 - [ ] Workload
 - [ ] Procrastinated

--- a/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Modules\Sleep;
+
+use App\Actions\LogBedTime;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class SleepBedTimeController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $journalEntry = $request->attributes->get('journal_entry');
+        $validated = $request->validate([
+            'bedtime' => ['required', 'date_format:H:i'],
+        ]);
+
+        $entry = new LogBedTime(
+            user: $request->user(),
+            entry: $journalEntry,
+            bedtime: $validated['bedtime'],
+        )->execute();
+
+        return new JournalEntryResource($entry)
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Modules\Sleep;
+
+use App\Actions\LogWakeUpTime;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class SleepWakeUpTimeController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $journalEntry = $request->attributes->get('journal_entry');
+        $validated = $request->validate([
+            'wake_up_time' => ['required', 'date_format:H:i'],
+        ]);
+
+        $entry = new LogWakeUpTime(
+            user: $request->user(),
+            entry: $journalEntry,
+            wakeUpTime: $validated['wake_up_time'],
+        )->execute();
+
+        return new JournalEntryResource($entry)
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/app/Http/Controllers/Marketing/Docs/Api/Modules/SleepController.php
+++ b/app/Http/Controllers/Marketing/Docs/Api/Modules/SleepController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\View\View;
+
+final class SleepController extends Controller
+{
+    public function index(): View
+    {
+        RecordMarketingPageVisit::dispatch(viewName: 'marketing.docs.api.modules.sleep')->onQueue('low');
+
+        return view('marketing.docs.api.modules.sleep');
+    }
+}

--- a/docs/bruno/JournalOS/Modules/Sleep/Log bedtime.bru
+++ b/docs/bruno/JournalOS/Modules/Sleep/Log bedtime.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Log bedtime
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{URL}}/journals/1/2025/12/29/sleep/bedtime
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "bedtime": "22:30"
+  }
+}

--- a/docs/bruno/JournalOS/Modules/Sleep/Log wake up time.bru
+++ b/docs/bruno/JournalOS/Modules/Sleep/Log wake up time.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Log wake up time
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{URL}}/journals/1/2025/12/29/sleep/wake_up_time
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "wake_up_time": "06:45"
+  }
+}

--- a/docs/bruno/JournalOS/Modules/Sleep/folder.bru
+++ b/docs/bruno/JournalOS/Modules/Sleep/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Sleep
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/bruno/JournalOS/Modules/folder.bru
+++ b/docs/bruno/JournalOS/Modules/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Modules
+  seq: 7
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/bruno/JournalOS/collection.bru
+++ b/docs/bruno/JournalOS/collection.bru
@@ -7,5 +7,5 @@ auth {
 }
 
 auth:bearer {
-  token: 1|sfj0hg5qOCdJN1Gfy8kb3sfWcze1GV527XoYFw4A32936251
+  token: 1|b0lDnntJORFiwLBjVWbUZSzMQuDgBpjyvBd5yFmw3d90910c
 }

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -26,6 +26,9 @@
             journalsDocumentation:
               '{{ str_starts_with( request()->route()->getName(),'marketing.docs.api.journals',) || str_starts_with( request()->route()->getName(),'marketing.docs.api.journal-entries',) ? 'true' : 'false' }}' ===
               'true',
+            modulesDocumentation:
+              '{{ str_starts_with( request()->route()->getName(),'marketing.docs.api.modules',) ? 'true' : 'false' }}' ===
+              'true',
           }"
           class="bg-light dark:bg-dark z-10 pt-16">
           <!-- concepts -->
@@ -100,6 +103,17 @@
               </div>
               <div>
                 <a href="{{ route('marketing.docs.api.journal-entries') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.journal-entries') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Journal entries</a>
+              </div>
+            </div>
+
+            <!-- modules -->
+            <div @click="modulesDocumentation = !modulesDocumentation" class="mb-3 flex cursor-pointer items-center justify-between rounded-md border border-transparent px-2 py-1 pl-3 text-xs text-gray-500 uppercase hover:border-gray-200 hover:bg-blue-50 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:bg-gray-800">
+              <h3>Modules</h3>
+              <x-phosphor-caret-right x-bind:class="modulesDocumentation ? 'rotate-90' : ''" class="h-4 w-4 text-gray-500 transition-transform duration-300" />
+            </div>
+            <div x-show="modulesDocumentation" class="mb-3 flex flex-col gap-y-2">
+              <div>
+                <a href="{{ route('marketing.docs.api.modules.sleep') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.sleep') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Sleep</a>
               </div>
             </div>
           </div>

--- a/resources/views/marketing/docs/api/modules/sleep.blade.php
+++ b/resources/views/marketing/docs/api/modules/sleep.blade.php
@@ -1,0 +1,132 @@
+<x-marketing-docs-layout :breadcrumbItems="[
+  ['label' => 'Home', 'route' => route('marketing.index')],
+  ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],
+  ['label' => 'Modules'],
+  ['label' => 'Sleep'],
+]">
+  <div class="py-16">
+    <x-marketing.docs.h1 title="Sleep module" />
+
+    <x-marketing.docs.table-of-content :items="[
+      [
+        'id' => 'log-a-bedtime',
+        'title' => 'Log a bedtime',
+      ],
+      [
+        'id' => 'log-a-wake-up-time',
+        'title' => 'Log a wake up time',
+      ],
+    ]" />
+
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2 dark:border-gray-700">
+      <div>
+        <p class="mb-2">The sleep module endpoints let you set the bedtime and wake up time for a journal entry.</p>
+        <p class="mb-2">Both endpoints return the updated journal entry.</p>
+      </div>
+      <div>
+        <x-marketing.docs.code title="Endpoints">
+          <div class="flex flex-col gap-y-2">
+            <a href="#log-a-bedtime">
+              <span class="text-orange-500">PUT</span>
+              /api/journals/{id}/{year}/{month}/{day}/sleep/bedtime
+            </a>
+            <a href="#log-a-wake-up-time">
+              <span class="text-orange-500">PUT</span>
+              /api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time
+            </a>
+          </div>
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/journals/{id}/{year}/{month}/{day}/sleep/bedtime -->
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2 dark:border-gray-700">
+      <div>
+        <x-marketing.docs.h2 id="log-a-bedtime" title="Log a bedtime" />
+        <p class="mb-10">This endpoint logs the bedtime for a journal entry.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute required name="year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute required name="month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute required name="day" type="integer" description="The day of the journal entry." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute required name="bedtime" type="string" description="The bedtime in HH:MM format." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
+          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
+          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
+          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/sleep/bedtime" verb="PUT" verbClass="text-yellow-700">
+          @include('marketing.docs.api.partials.journal-entry-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="log-a-wake-up-time" title="Log a wake up time" />
+        <p class="mb-10">This endpoint logs the wake up time for a journal entry.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute required name="year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute required name="month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute required name="day" type="integer" description="The day of the journal entry." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute required name="wake_up_time" type="string" description="The wake up time in HH:MM format." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
+          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
+          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
+          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time" verb="PUT" verbClass="text-yellow-700">
+          @include('marketing.docs.api.partials.journal-entry-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+  </div>
+</x-marketing-docs-layout>

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Api\Auth\LoginController;
 use App\Http\Controllers\Api\HealthController;
 use App\Http\Controllers\Api\Journals;
 use App\Http\Controllers\Api\Journals\JournalEntryController;
+use App\Http\Controllers\Api\Journals\Modules\Sleep\SleepBedTimeController;
+use App\Http\Controllers\Api\Journals\Modules\Sleep\SleepWakeUpTimeController;
 use App\Http\Controllers\Api\Settings;
 use App\Http\Controllers\Api\Settings\Account\DestroyAccountController;
 use App\Http\Controllers\Api\Settings\Account\PruneAccountController;
@@ -39,6 +41,18 @@ Route::name('api.')->group(function (): void {
                     ->whereNumber('month')
                     ->whereNumber('day')
                     ->name('journal.entry.show');
+
+                Route::put('journals/{id}/{year}/{month}/{day}/sleep/bedtime', [SleepBedTimeController::class, 'update'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.sleep.bedtime.update');
+
+                Route::put('journals/{id}/{year}/{month}/{day}/sleep/wake_up_time', [SleepWakeUpTimeController::class, 'update'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.sleep.wake_up_time.update');
             });
 
             // settings

--- a/routes/marketing.php
+++ b/routes/marketing.php
@@ -21,3 +21,4 @@ Route::get('/docs/api/emails', [Docs\Api\EmailSentController::class, 'index'])->
 Route::get('/docs/api/account', [Docs\Api\AccountController::class, 'index'])->name('marketing.docs.api.account');
 Route::get('/docs/api/journals', [Docs\Api\JournalController::class, 'index'])->name('marketing.docs.api.journals');
 Route::get('/docs/api/journal-entries', [Docs\Api\JournalEntryController::class, 'index'])->name('marketing.docs.api.journal-entries');
+Route::get('/docs/api/modules/sleep', [Docs\Api\Modules\SleepController::class, 'index'])->name('marketing.docs.api.modules.sleep');

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Modules\Sleep;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SleepBedTimeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $singleJsonStructure = [
+        'data' => [
+            'type',
+            'id',
+            'attributes' => [
+                'journal_id',
+                'day',
+                'month',
+                'year',
+                'modules' => [
+                    'sleep' => [
+                        'bedtime',
+                        'wake_up_time',
+                        'sleep_duration_in_minutes',
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+            'links' => [
+                'self',
+            ],
+        ],
+    ];
+
+    #[Test]
+    public function it_logs_bedtime_for_a_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 12,
+            'month' => 4,
+            'year' => 2025,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/bedtime', [
+            'bedtime' => '22:30',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure($this->singleJsonStructure);
+        $response->assertJson([
+            'data' => [
+                'id' => (string) $entry->id,
+                'attributes' => [
+                    'modules' => [
+                        'sleep' => [
+                            'bedtime' => '22:30',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('journal_entries', [
+            'id' => $entry->id,
+            'bedtime' => '22:30',
+        ]);
+    }
+
+    #[Test]
+    public function it_requires_a_valid_bedtime_format(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/bedtime', [
+            'bedtime' => '22-30',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('bedtime');
+    }
+
+    #[Test]
+    public function it_rejects_bedtime_updates_for_other_users_entries(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/bedtime', [
+            'bedtime' => '22:30',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
@@ -76,9 +76,8 @@ final class SleepBedTimeControllerTest extends TestCase
             ],
         ]);
 
-        $this->assertDatabaseHas('journal_entries', [
-            'id' => $entry->id,
-        ]);
+        $entry->refresh();
+        $this->assertEquals('22:30', $entry->bedtime);
     }
 
     #[Test]

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
@@ -78,7 +78,6 @@ final class SleepBedTimeControllerTest extends TestCase
 
         $this->assertDatabaseHas('journal_entries', [
             'id' => $entry->id,
-            'bedtime' => '22:30',
         ]);
     }
 

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -78,7 +78,6 @@ final class SleepWakeUpTimeControllerTest extends TestCase
 
         $this->assertDatabaseHas('journal_entries', [
             'id' => $entry->id,
-            'wake_up_time' => '06:45',
         ]);
     }
 

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -76,9 +76,8 @@ final class SleepWakeUpTimeControllerTest extends TestCase
             ],
         ]);
 
-        $this->assertDatabaseHas('journal_entries', [
-            'id' => $entry->id,
-        ]);
+        $entry->refresh();
+        $this->assertEquals('06:45', $entry->wake_up_time);
     }
 
     #[Test]

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Modules\Sleep;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SleepWakeUpTimeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $singleJsonStructure = [
+        'data' => [
+            'type',
+            'id',
+            'attributes' => [
+                'journal_id',
+                'day',
+                'month',
+                'year',
+                'modules' => [
+                    'sleep' => [
+                        'bedtime',
+                        'wake_up_time',
+                        'sleep_duration_in_minutes',
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+            'links' => [
+                'self',
+            ],
+        ],
+    ];
+
+    #[Test]
+    public function it_logs_wake_up_time_for_a_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 12,
+            'month' => 4,
+            'year' => 2025,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/wake_up_time', [
+            'wake_up_time' => '06:45',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure($this->singleJsonStructure);
+        $response->assertJson([
+            'data' => [
+                'id' => (string) $entry->id,
+                'attributes' => [
+                    'modules' => [
+                        'sleep' => [
+                            'wake_up_time' => '06:45',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('journal_entries', [
+            'id' => $entry->id,
+            'wake_up_time' => '06:45',
+        ]);
+    }
+
+    #[Test]
+    public function it_requires_a_valid_wake_up_time_format(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/wake_up_time', [
+            'wake_up_time' => '06-45',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('wake_up_time');
+    }
+
+    #[Test]
+    public function it_rejects_wake_up_time_updates_for_other_users_entries(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/sleep/wake_up_time', [
+            'wake_up_time' => '06:45',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
### Motivation
- Add API endpoints to log bedtime and wake up time for a journal entry and expose them to API clients.
- Keep request validation consistent with existing API controllers by performing validation inside controller methods instead of using form request classes.
- Provide discoverability via Bruno collection and marketing documentation for the new module endpoints.
- Add automated feature tests to cover success, validation, and ownership denial paths for the new endpoints.

### Description
- Added routes for `PUT /api/journals/{id}/{year}/{month}/{day}/sleep/bedtime` and `PUT /api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time` in `routes/api.php` and wired them to new controllers.
- Implemented `SleepBedTimeController` and `SleepWakeUpTimeController` that use `Request->validate()` to perform inline validation and call the `LogBedTime` / `LogWakeUpTime` actions, returning a `JournalEntryResource`.
- Removed the API form request classes `LogBedTimeRequest` and `LogWakeUpTimeRequest` and updated the controllers accordingly.
- Added Bruno collection files, marketing docs view and controller, and feature tests under `tests/Feature/Controllers/Api/Journals/Modules/Sleep` to document and validate the behavior.

### Testing
- Attempted to run `vendor/bin/pint --dirty` for formatting checks, but it failed because `vendor/bin/pint` is not present (Composer dependencies not installed).
- Attempted to run `php artisan test tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php`, but it failed because `vendor/autoload.php` is missing (Composer dependencies not installed).
- Feature tests were added for both controllers (success, validation, and ownership denial), but they were not executed successfully in this environment due to missing dependencies.
- To run tests and formatting locally or in CI install dependencies with `composer install` then run `vendor/bin/pint --dirty` and `php artisan test --filter=SleepBedTimeControllerTest` (or run the two test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549fc4faec8320afa3caed6e9e8039)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added API endpoints to log sleep data for journal entries:
  - PUT /api/journals/{id}/{year}/{month}/{day}/sleep/bedtime — Log bedtime (H:i)
  - PUT /api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time — Log wake-up time (H:i)

- Routes added and named: journal.entry.sleep.bedtime.update and journal.entry.sleep.wake_up_time.update

- New controllers:
  - SleepBedTimeController — inline Request->validate() for bedtime, calls LogBedTime action, returns JournalEntryResource (200)
  - SleepWakeUpTimeController — inline Request->validate() for wake_up_time, calls LogWakeUpTime action, returns JournalEntryResource (200)

- Removed LogBedTimeRequest and LogWakeUpTimeRequest form request classes; validation consolidated inline in controllers to match existing API pattern

- Documentation and marketing:
  - New marketing docs view for Sleep module (resources/views/marketing/docs/api/modules/sleep.blade.php)
  - Marketing controller and route added for the Sleep docs page
  - Sidebar/docs layout updated to include Modules → Sleep link

- Bruno scripts/collection files added for Sleep module endpoints (docs/bruno/JournalOS/Modules/Sleep and updated collection token)

- Tests added:
  - Feature tests for bedtime and wake_up_time endpoints covering success, validation (invalid H:i), and ownership/authorization denial (404)
  - Tests located under tests/Feature/Controllers/Api/Journals/Modules/Sleep

- CI/local notes:
  - Composer dependencies are required to run checks; run composer install before vendor/bin/pint and php artisan test (vendor/autoload.php and vendor/bin/pint were missing in the PR environment)

- Misc:
  - Minor TODO added: "ability to reset an entire day"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->