### PR TITLE
feat: add work module to api

### DIFF
--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Modules\Work;
+
+use App\Actions\LogHasWorked;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class WorkController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $journalEntry = $request->attributes->get('journal_entry');
+        $validated = $request->validate([
+            'worked' => ['required', 'string', 'in:yes,no'],
+        ]);
+
+        $entry = new LogHasWorked(
+            user: $request->user(),
+            entry: $journalEntry,
+            hasWorked: $validated['worked'],
+        )->execute();
+
+        return new JournalEntryResource($entry)
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/app/Http/Controllers/Marketing/Docs/Api/Modules/WorkController.php
+++ b/app/Http/Controllers/Marketing/Docs/Api/Modules/WorkController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\View\View;
+
+final class WorkController extends Controller
+{
+    public function index(): View
+    {
+        RecordMarketingPageVisit::dispatch(viewName: 'marketing.docs.api.modules.work')->onQueue('low');
+
+        return view('marketing.docs.api.modules.work');
+    }
+}

--- a/app/Http/Resources/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntryResource.php
@@ -34,6 +34,9 @@ final class JournalEntryResource extends JsonResource
                         'wake_up_time' => $this->wake_up_time,
                         'sleep_duration_in_minutes' => $this->sleep_duration_in_minutes,
                     ],
+                    'work' => [
+                        'worked' => $this->worked,
+                    ],
                 ],
                 'created_at' => $this->created_at->timestamp,
                 'updated_at' => $this->updated_at?->timestamp,

--- a/docs/bruno/JournalOS/Modules/Work/Log work status.bru
+++ b/docs/bruno/JournalOS/Modules/Work/Log work status.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Log work status
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{URL}}/journals/1/2025/12/29/work
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "worked": "yes"
+  }
+}

--- a/docs/bruno/JournalOS/Modules/Work/folder.bru
+++ b/docs/bruno/JournalOS/Modules/Work/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Work
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -115,6 +115,9 @@
               <div>
                 <a href="{{ route('marketing.docs.api.modules.sleep') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.sleep') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Sleep</a>
               </div>
+              <div>
+                <a href="{{ route('marketing.docs.api.modules.work') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.work') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Work</a>
+              </div>
             </div>
           </div>
         </div>

--- a/resources/views/marketing/docs/api/entries/journal-entry.blade.php
+++ b/resources/views/marketing/docs/api/entries/journal-entry.blade.php
@@ -49,23 +49,7 @@
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->
-        <x-marketing.docs.response-attributes>
-          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
-          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
-          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
-          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
-          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
-        </x-marketing.docs.response-attributes>
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
       </div>
       <div>
         <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}" verb="GET" verbClass="text-blue-700">

--- a/resources/views/marketing/docs/api/modules/sleep.blade.php
+++ b/resources/views/marketing/docs/api/modules/sleep.blade.php
@@ -59,23 +59,7 @@
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->
-        <x-marketing.docs.response-attributes>
-          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
-          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
-          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
-          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
-          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
-        </x-marketing.docs.response-attributes>
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
       </div>
       <div>
         <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/sleep/bedtime" verb="PUT" verbClass="text-yellow-700">
@@ -104,23 +88,7 @@
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->
-        <x-marketing.docs.response-attributes>
-          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
-          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
-          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
-          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
-          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
-        </x-marketing.docs.response-attributes>
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
       </div>
       <div>
         <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/sleep/wake_up_time" verb="PUT" verbClass="text-yellow-700">

--- a/resources/views/marketing/docs/api/modules/work.blade.php
+++ b/resources/views/marketing/docs/api/modules/work.blade.php
@@ -1,0 +1,79 @@
+<x-marketing-docs-layout :breadcrumbItems="[
+  ['label' => 'Home', 'route' => route('marketing.index')],
+  ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],
+  ['label' => 'Modules'],
+  ['label' => 'Work'],
+]">
+  <div class="py-16">
+    <x-marketing.docs.h1 title="Work module" />
+
+    <x-marketing.docs.table-of-content :items="[
+      [
+        'id' => 'log-work-status',
+        'title' => 'Log work status',
+      ],
+    ]" />
+
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2 dark:border-gray-700">
+      <div>
+        <p class="mb-2">The work module endpoint lets you set whether you worked for a journal entry.</p>
+        <p class="mb-2">The endpoint returns the updated journal entry.</p>
+      </div>
+      <div>
+        <x-marketing.docs.code title="Endpoints">
+          <div class="flex flex-col gap-y-2">
+            <a href="#log-work-status">
+              <span class="text-orange-500">PUT</span>
+              /api/journals/{id}/{year}/{month}/{day}/work
+            </a>
+          </div>
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/journals/{id}/{year}/{month}/{day}/work -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="log-work-status" title="Log work status" />
+        <p class="mb-10">This endpoint logs whether you worked for a journal entry.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute required name="year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute required name="month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute required name="day" type="integer" description="The day of the journal entry." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute required name="worked" type="string" description="Whether you worked on this day. Accepted values are yes or no." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        <x-marketing.docs.response-attributes>
+          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
+          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
+          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
+          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
+          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
+          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
+        </x-marketing.docs.response-attributes>
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/work" verb="PUT" verbClass="text-yellow-700">
+          @include('marketing.docs.api.partials.journal-entry-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+  </div>
+</x-marketing-docs-layout>

--- a/resources/views/marketing/docs/api/modules/work.blade.php
+++ b/resources/views/marketing/docs/api/modules/work.blade.php
@@ -51,23 +51,7 @@
         </x-marketing.docs.query-parameters>
 
         <!-- response attributes -->
-        <x-marketing.docs.response-attributes>
-          <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
-          <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
-          <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
-          <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
-          <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
-          <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
-          <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
-        </x-marketing.docs.response-attributes>
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
       </div>
       <div>
         <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/work" verb="PUT" verbClass="text-yellow-700">

--- a/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
@@ -1,0 +1,19 @@
+<x-marketing.docs.response-attributes>
+  <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
+  <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />
+  <x-marketing.docs.attribute name="attributes" type="object" description="The attributes of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.journal_id" type="integer" description="The ID of the journal." />
+  <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
+  <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
+  <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.modules.sleep.wake_up_time" type="string" description="The wake up time of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.modules.sleep.sleep_duration_in_minutes" type="integer" description="The sleep duration in minutes." />
+  <x-marketing.docs.attribute name="attributes.modules.work" type="object" description="The work module payload." />
+  <x-marketing.docs.attribute name="attributes.modules.work.worked" type="string" description="Whether you worked on the journal entry." />
+  <x-marketing.docs.attribute name="attributes.created_at" type="integer" description="The date and time the object was created, in Unix timestamp format." />
+  <x-marketing.docs.attribute name="attributes.updated_at" type="integer" description="The date and time the object was last updated, in Unix timestamp format." />
+  <x-marketing.docs.attribute name="links" type="object" description="The links to access the journal entry." />
+</x-marketing.docs.response-attributes>

--- a/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
@@ -47,6 +47,12 @@
   "sleep_duration_in_minutes":
   <span class="text-rose-800">495</span>
 </div>
+<div class="pl-16">},</div>
+<div class="pl-16">"work": {</div>
+<div class="pl-20">
+  "worked":
+  <span class="text-lime-700">"yes"</span>
+</div>
 <div class="pl-16">}</div>
 <div class="pl-12">},</div>
 <div class="pl-12">

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\Journals;
 use App\Http\Controllers\Api\Journals\JournalEntryController;
 use App\Http\Controllers\Api\Journals\Modules\Sleep\SleepBedTimeController;
 use App\Http\Controllers\Api\Journals\Modules\Sleep\SleepWakeUpTimeController;
+use App\Http\Controllers\Api\Journals\Modules\Work\WorkController;
 use App\Http\Controllers\Api\Settings;
 use App\Http\Controllers\Api\Settings\Account\DestroyAccountController;
 use App\Http\Controllers\Api\Settings\Account\PruneAccountController;
@@ -53,6 +54,12 @@ Route::name('api.')->group(function (): void {
                     ->whereNumber('month')
                     ->whereNumber('day')
                     ->name('journal.entry.sleep.wake_up_time.update');
+
+                Route::put('journals/{id}/{year}/{month}/{day}/work', [WorkController::class, 'update'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.work.update');
             });
 
             // settings

--- a/routes/marketing.php
+++ b/routes/marketing.php
@@ -22,3 +22,4 @@ Route::get('/docs/api/account', [Docs\Api\AccountController::class, 'index'])->n
 Route::get('/docs/api/journals', [Docs\Api\JournalController::class, 'index'])->name('marketing.docs.api.journals');
 Route::get('/docs/api/journal-entries', [Docs\Api\JournalEntryController::class, 'index'])->name('marketing.docs.api.journal-entries');
 Route::get('/docs/api/modules/sleep', [Docs\Api\Modules\SleepController::class, 'index'])->name('marketing.docs.api.modules.sleep');
+Route::get('/docs/api/modules/work', [Docs\Api\Modules\WorkController::class, 'index'])->name('marketing.docs.api.modules.work');

--- a/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
@@ -31,6 +31,9 @@ final class JournalEntryControllerTest extends TestCase
                         'wake_up_time',
                         'sleep_duration_in_minutes',
                     ],
+                    'work' => [
+                        'worked',
+                    ],
                 ],
                 'created_at',
                 'updated_at',
@@ -78,6 +81,9 @@ final class JournalEntryControllerTest extends TestCase
                             'bedtime' => '22:30',
                             'wake_up_time' => '06:45',
                             'sleep_duration_in_minutes' => '495',
+                        ],
+                        'work' => [
+                            'worked' => null,
                         ],
                     ],
                 ],

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
@@ -31,6 +31,9 @@ final class SleepBedTimeControllerTest extends TestCase
                         'wake_up_time',
                         'sleep_duration_in_minutes',
                     ],
+                    'work' => [
+                        'worked',
+                    ],
                 ],
                 'created_at',
                 'updated_at',

--- a/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Sleep/SleepWakeUpTimeControllerTest.php
@@ -31,6 +31,9 @@ final class SleepWakeUpTimeControllerTest extends TestCase
                         'wake_up_time',
                         'sleep_duration_in_minutes',
                     ],
+                    'work' => [
+                        'worked',
+                    ],
                 ],
                 'created_at',
                 'updated_at',

--- a/tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php
@@ -31,6 +31,9 @@ final class WorkControllerTest extends TestCase
                         'wake_up_time',
                         'sleep_duration_in_minutes',
                     ],
+                    'work' => [
+                        'worked',
+                    ],
                 ],
                 'created_at',
                 'updated_at',

--- a/tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Modules\Work;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class WorkControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $singleJsonStructure = [
+        'data' => [
+            'type',
+            'id',
+            'attributes' => [
+                'journal_id',
+                'day',
+                'month',
+                'year',
+                'modules' => [
+                    'sleep' => [
+                        'bedtime',
+                        'wake_up_time',
+                        'sleep_duration_in_minutes',
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+            'links' => [
+                'self',
+            ],
+        ],
+    ];
+
+    #[Test]
+    public function it_logs_work_status_for_a_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 12,
+            'month' => 4,
+            'year' => 2025,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/work', [
+            'worked' => 'yes',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure($this->singleJsonStructure);
+        $response->assertJson([
+            'data' => [
+                'id' => (string) $entry->id,
+            ],
+        ]);
+
+        $entry->refresh();
+        $this->assertEquals('yes', $entry->worked);
+    }
+
+    #[Test]
+    public function it_requires_worked_to_be_yes_or_no(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/work', [
+            'worked' => 'maybe',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('worked');
+    }
+
+    #[Test]
+    public function it_requires_worked_to_be_present(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/work', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('worked');
+    }
+
+    #[Test]
+    public function it_rejects_work_updates_for_other_users_entries(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/journals/' . $journal->id . '/2025/4/12/work', [
+            'worked' => 'yes',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an API endpoint to set the `worked` flag on a single journal entry so API clients can mirror the existing web behavior.  
- Expose the endpoint in the API surface with proper validation and resource response to keep parity with other modules (sleep).  
- Ship documentation (marketing + Bruno examples) so consumers know how to call the endpoint.  
- Add feature tests to enforce validation and access control for the new API.

### Description
- Add `WorkController` at `app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php` which validates `worked` (`in:yes,no`), executes `LogHasWorked`, and returns a `JournalEntryResource` JSON response.  
- Register the route `PUT /api/journals/{id}/{year}/{month}/{day}/work` in `routes/api.php` as `journal.entry.work.update`.  
- Add marketing docs and menu link (`resources/views/marketing/docs/api/modules/work.blade.php` and updated `resources/views/layouts/docs.blade.php`), and add a marketing controller `App\Http\Controllers\Marketing\Docs\Api\Modules\WorkController`.  
- Add Bruno examples under `docs/bruno/JournalOS/Modules/Work/` and a feature test file at `tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php` to cover happy path, validation and cross-user rejection.

### Testing
- Attempted to run formatter with `vendor/bin/pint --dirty` but it failed because `vendor/bin/pint` is missing (project dependencies not installed).  
- Attempted to run the new feature test with `php artisan test tests/Feature/Controllers/Api/Journals/Modules/Work/WorkControllerTest.php` but it failed because `vendor/autoload.php` is missing (dependencies not installed).  
- Note: tests were added and ready to run once `composer install` has been executed in the environment; no tests passed or failed due to missing vendor dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554d9610d48320b1739c46a4a0102c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New Work module API endpoint: PUT /api/journals/{id}/{year}/{month}/{day}/work to set a journal entry's worked flag (accepted values: "yes", "no")
- Controller: added App\Http\Controllers\Api\Journals\Modules\Work\WorkController with update action validating input, dispatching LogHasWorked, and returning JournalEntryResource
- Route: registered route journal.entry.work.update (PUT) with year/month/day constraints
- API docs: marketing documentation page and route added for the Work module; sidebar menu updated
- Documentation examples: Bruno examples added (docs/bruno/JournalOS/Modules/Work/)
- Resource updates: JournalEntryResource exposes modules.work.worked in API responses; shared partials added for response attributes/examples
- Tests: feature tests added covering happy path, validation (required and allowed values), and cross-user access control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->