### PR TITLE
feat: hide work information when needed

### DIFF
--- a/resources/views/app/journal/entry/partials/work.blade.php
+++ b/resources/views/app/journal/entry/partials/work.blade.php
@@ -13,21 +13,36 @@
     </div>
   </x-slot>
 
-  <div id="work-container" class="space-y-4">
-    <div class="space-y-4">
+  <div id="work-container" class="space-y-4" x-data="{ showWorkDetails: {{ $entry->worked === 'yes' ? 'true' : 'false' }} }">
+    <div>
       <!-- Have you worked today? -->
       <div class="space-y-2">
         <p>{{ __('Have you worked today?') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-          <x-button.yes name="worked" value="yes" x-target="work-container notifications work-reset" :action="$module['has_worked_url']" selected="{{ $entry->worked === 'yes' }}" />
-          <x-button.no name="worked" value="no" x-target="work-container notifications work-reset" :action="$module['has_worked_url']" selected="{{ $entry->worked === 'no' }}" />
+          <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
+            <x-form x-target="work-container notifications work-reset" :action="$module['has_worked_url']" method="put" class="h-full">
+              <input type="hidden" name="worked" value="yes" />
+              <button @click="showWorkDetails = true" type="submit" class="{{ $entry->worked === 'yes' ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center first:rounded-l-lg last:rounded-r-lg hover:bg-green-50 dark:hover:bg-green-900/40">
+                {{ __('Yes') }}
+              </button>
+            </x-form>
+          </div>
+          <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
+            <x-form x-target="work-container notifications work-reset" :action="$module['has_worked_url']" method="put" class="h-full">
+              <input type="hidden" name="worked" value="no" />
+              <button @click="showWorkDetails = false" type="submit" class="{{ $entry->worked === 'no' ? 'bg-red-50 font-bold dark:bg-red-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center first:rounded-l-lg last:rounded-r-lg hover:bg-red-50 dark:hover:bg-red-900/40">
+                {{ __('No') }}
+              </button>
+            </x-form>
+          </div>
         </div>
       </div>
 
-      <!-- Work mode -->
-      <div class="space-y-2">
-        <p>{{ __('How did you work?') }}</p>
-        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+      <div x-show="showWorkDetails" x-cloak class="space-y-4 mt-4">
+        <!-- Work mode -->
+        <div class="space-y-2">
+          <p>{{ __('How did you work?') }}</p>
+          <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
           @foreach ($module['work_modes'] as $option)
             <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
               <x-form x-target="work-container notifications work-reset" :action="$module['work_mode_url']" method="put" class="h-full">
@@ -38,13 +53,13 @@
               </x-form>
             </div>
           @endforeach
+          </div>
         </div>
-      </div>
 
-      <!-- Work load -->
-      <div class="space-y-2">
-        <p>{{ __('How much did you work?') }}</p>
-        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <!-- Work load -->
+        <div class="space-y-2">
+          <p>{{ __('How much did you work?') }}</p>
+          <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
           @foreach ($module['work_loads'] as $option)
             <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
               <x-form x-target="work-container notifications work-reset" :action="$module['work_load_url']" method="put" class="h-full">
@@ -55,15 +70,16 @@
               </x-form>
             </div>
           @endforeach
+          </div>
         </div>
-      </div>
 
-      <!-- Procrastination -->
-      <div class="space-y-2">
-        <p>{{ __('Did you procrastinate (be honest)?') }}</p>
-        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <!-- Procrastination -->
+        <div class="space-y-2">
+          <p>{{ __('Did you procrastinate (be honest)?') }}</p>
+          <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
           <x-button.yes name="work_procrastinated" value="yes" x-target="work-container notifications work-reset" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'yes' }}" />
           <x-button.no name="work_procrastinated" value="no" x-target="work-container notifications work-reset" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'no' }}" />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Hide work details when not working**: Work mode, work load, and procrastination sections are now conditionally hidden when the user selects "No" for "Have you worked today?"
- **Interactive state management**: Implemented Alpine.js-based state (`showWorkDetails`) to dynamically show/hide detailed work sections based on user selection
- **Improved UX**: Work details visibility automatically initializes based on the entry's current `worked` status and updates when the user toggles between "Yes" and "No"
- **Refactored form structure**: Each work status option ("Yes"/"No") is now submitted via its own individual form instead of static button pairs
- **Visual feedback**: Buttons now conditionally highlight based on current selection with styled backgrounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->