### PR TITLE
feat: indicate presence of content in a journal entry

### DIFF
--- a/app/Actions/LogActivityIntensity.php
+++ b/app/Actions/LogActivityIntensity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class LogActivityIntensity
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -59,5 +61,10 @@ final readonly class LogActivityIntensity
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogActivityType.php
+++ b/app/Actions/LogActivityType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class LogActivityType
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -59,5 +61,10 @@ final readonly class LogActivityType
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogBedTime.php
+++ b/app/Actions/LogBedTime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Jobs\CalculateSleepDuration;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogBedTime
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->calculateSleepDuration();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -74,5 +76,10 @@ final readonly class LogBedTime
     private function calculateSleepDuration(): void
     {
         CalculateSleepDuration::dispatch($this->entry)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogHasDonePhysicalActivity.php
+++ b/app/Actions/LogHasDonePhysicalActivity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class LogHasDonePhysicalActivity
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -59,5 +61,10 @@ final readonly class LogHasDonePhysicalActivity
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogHasWorked.php
+++ b/app/Actions/LogHasWorked.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogHasWorked
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogHasWorked
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogTravelMode.php
+++ b/app/Actions/LogTravelMode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -32,6 +33,7 @@ final readonly class LogTravelMode
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -66,5 +68,10 @@ final readonly class LogTravelMode
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogTravelledToday.php
+++ b/app/Actions/LogTravelledToday.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogTravelledToday
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogTravelledToday
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogTypeOfDay.php
+++ b/app/Actions/LogTypeOfDay.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogTypeOfDay
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogTypeOfDay
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogWakeUpTime.php
+++ b/app/Actions/LogWakeUpTime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Jobs\CalculateSleepDuration;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogWakeUpTime
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->calculateSleepDuration();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -74,5 +76,10 @@ final readonly class LogWakeUpTime
     private function calculateSleepDuration(): void
     {
         CalculateSleepDuration::dispatch($this->entry)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogWorkLoad.php
+++ b/app/Actions/LogWorkLoad.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogWorkLoad
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogWorkLoad
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogWorkMode.php
+++ b/app/Actions/LogWorkMode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogWorkMode
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogWorkMode
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/LogWorkProcrastinated.php
+++ b/app/Actions/LogWorkProcrastinated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -30,6 +31,7 @@ final readonly class LogWorkProcrastinated
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -58,5 +60,10 @@ final readonly class LogWorkProcrastinated
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/ResetDayTypeData.php
+++ b/app/Actions/ResetDayTypeData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -25,6 +26,7 @@ final readonly class ResetDayTypeData
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -49,5 +51,10 @@ final readonly class ResetDayTypeData
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/ResetPhysicalActivityData.php
+++ b/app/Actions/ResetPhysicalActivityData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class ResetPhysicalActivityData
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -52,5 +54,10 @@ final readonly class ResetPhysicalActivityData
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/ResetSleepData.php
+++ b/app/Actions/ResetSleepData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -27,6 +28,7 @@ final readonly class ResetSleepData
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -51,5 +53,10 @@ final readonly class ResetSleepData
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/ResetTravelData.php
+++ b/app/Actions/ResetTravelData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -26,6 +27,7 @@ final readonly class ResetTravelData
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -50,5 +52,10 @@ final readonly class ResetTravelData
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Actions/ResetWorkData.php
+++ b/app/Actions/ResetWorkData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
@@ -28,6 +29,7 @@ final readonly class ResetWorkData
 
         $this->logUserAction();
         $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
 
         return $this->entry;
     }
@@ -52,5 +54,10 @@ final readonly class ResetWorkData
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
     }
 }

--- a/app/Helpers/JournalHelper.php
+++ b/app/Helpers/JournalHelper.php
@@ -96,7 +96,7 @@ final class JournalHelper
      *      'day' => 1,
      *      'is_today' => false,
      *      'is_selected' => false,
-     *      'has_blocks' => true,
+     *      'has_content' => true,
      *      'url' => '/journal/2023/01/01',
      *   ]
      *
@@ -109,13 +109,21 @@ final class JournalHelper
      */
     public static function getDaysInMonth(Journal $journal, int $year, int $month, int $day): Collection
     {
+        // Get all entries for this month with their has_content status
+        $entriesWithContent = $journal->entries()
+            ->where('year', $year)
+            ->where('month', $month)
+            ->where('has_content', true)
+            ->pluck('day')
+            ->flip();
+
         return collect(range(1, cal_days_in_month(CAL_GREGORIAN, $month, $year)))
             ->mapWithKeys(fn(int $currentDay): array => [
                 $currentDay => (object) [
                     'day' => $currentDay,
                     'is_today' => Date::createFromDate($year, $month, $currentDay)->isToday(),
                     'is_selected' => $currentDay === $day,
-                    'has_blocks' => 0,
+                    'has_content' => $entriesWithContent->has($currentDay),
                     'url' => route('journal.entry.show', [
                         'slug' => $journal->slug,
                         'year' => $year,

--- a/app/Jobs/CheckPresenceOfContentInJournalEntry.php
+++ b/app/Jobs/CheckPresenceOfContentInJournalEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\JournalEntry;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Check if the journal entry has any content in it.
+ * If there is, it sets the has_content field to true, otherwise to false.
+ * This job is triggered once any action is done on a journal entry.
+ */
+final class CheckPresenceOfContentInJournalEntry implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public JournalEntry $entry,
+    ) {}
+
+    public function handle(): void
+    {
+        $excludedFields = [
+            'id',
+            'journal_id',
+            'day',
+            'month',
+            'year',
+            'has_content',
+            'created_at',
+            'updated_at',
+        ];
+
+        $hasContent = false;
+
+        foreach ($this->entry->getAttributes() as $field => $value) {
+            if (! in_array($field, $excludedFields) && $value !== null) {
+                $hasContent = true;
+                break;
+            }
+        }
+
+        $this->entry->has_content = $hasContent;
+        $this->entry->save();
+    }
+}

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Date;
  * @property int $day
  * @property int $month
  * @property int $year
+ * @property bool $has_content
  * @property string|null $bedtime # Format: 'HH:MM'
  * @property string|null $wake_up_time # Format: 'HH:MM'
  * @property string|null $sleep_duration_in_minutes # Format: '12'
@@ -61,6 +62,7 @@ final class JournalEntry extends Model
         'day',
         'month',
         'year',
+        'has_content',
         'bedtime',
         'wake_up_time',
         'sleep_duration_in_minutes',
@@ -85,6 +87,7 @@ final class JournalEntry extends Model
     protected function casts(): array
     {
         return [
+            'has_content' => 'boolean',
             'bedtime' => 'encrypted',
             'wake_up_time' => 'encrypted',
             'sleep_duration_in_minutes' => 'encrypted',

--- a/database/migrations/2025_12_04_040809_create_journal_entries_table.php
+++ b/database/migrations/2025_12_04_040809_create_journal_entries_table.php
@@ -18,6 +18,7 @@ return new class extends Migration {
             $table->integer('day');
             $table->integer('month');
             $table->integer('year');
+            $table->boolean('has_content')->default(false);
             $table->timestamps();
             $table->foreign('journal_id')->references('id')->on('journals')->onDelete('cascade');
         });

--- a/database/migrations/2025_12_15_024534_add_sleep_to_journal_entries.php
+++ b/database/migrations/2025_12_15_024534_add_sleep_to_journal_entries.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('journal_entries', function (Blueprint $table): void {
-            $table->text('bedtime')->nullable()->after('year');
+            $table->text('bedtime')->nullable()->after('has_content');
             $table->text('wake_up_time')->nullable()->after('bedtime');
             $table->text('sleep_duration_in_minutes')->nullable()->after('wake_up_time');
         });

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,109 +2,109 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-02T02:25:42+00:00</lastmod>
+    <lastmod>2026-01-02T03:27:14+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>

--- a/resources/views/app/journal/entry/partials/day_type.blade.php
+++ b/resources/views/app/journal/entry/partials/day_type.blade.php
@@ -4,7 +4,7 @@
   <x-slot:action>
     <div id="day-type-reset">
       @if ($module['display_reset'])
-        <x-form x-target="day-type-container notifications day-type-reset" :action="$module['reset_url']" method="put">
+        <x-form x-target="day-type-container notifications day-type-reset days-listing months-listing" :action="$module['reset_url']" method="put">
           <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
             {{ __('Reset') }}
           </button>
@@ -19,7 +19,7 @@
       <p>{{ __('What type of day was it?') }}</p>
       <div class="flex flex-wrap justify-center gap-2">
         @foreach ($module['day_types'] as $option)
-          <x-form x-target="day-type-container notifications day-type-reset" :action="$module['day_type_url']" method="put">
+          <x-form x-target="day-type-container notifications day-type-reset days-listing months-listing" :action="$module['day_type_url']" method="put">
             <input type="hidden" name="day_type" value="{{ $option['value'] }}" />
             <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} cursor-pointer rounded-lg border border-gray-200 px-3 py-2 hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">
               {{ $option['label'] }}

--- a/resources/views/app/journal/entry/partials/physical_activity.blade.php
+++ b/resources/views/app/journal/entry/partials/physical_activity.blade.php
@@ -4,7 +4,7 @@
   <x-slot:action>
     <div id="physical-activity-reset">
       @if ($module['display_reset'])
-        <x-form x-target="physical-activity-container notifications physical-activity-reset" :action="$module['reset_url']" method="put">
+        <x-form x-target="physical-activity-container notifications physical-activity-reset days-listing months-listing" :action="$module['reset_url']" method="put">
           <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
             {{ __('Reset') }}
           </button>
@@ -22,8 +22,8 @@
       <div class="space-y-2">
         <p>{{ __('Did you do physical activity?') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-          <x-button.yes name="has_done_physical_activity" value="yes" x-target="physical-activity-container notifications physical-activity-reset" :action="$module['has_done_url']" selected="{{ $entry->has_done_physical_activity === 'yes' }}" @click="showActivityDetails = true" />
-          <x-button.no name="has_done_physical_activity" value="no" x-target="physical-activity-container notifications physical-activity-reset" :action="$module['has_done_url']" selected="{{ $entry->has_done_physical_activity === 'no' }}" @click="showActivityDetails = false" />
+          <x-button.yes name="has_done_physical_activity" value="yes" x-target="physical-activity-container notifications physical-activity-reset days-listing months-listing" :action="$module['has_done_url']" selected="{{ $entry->has_done_physical_activity === 'yes' }}" @click="showActivityDetails = true" />
+          <x-button.no name="has_done_physical_activity" value="no" x-target="physical-activity-container notifications physical-activity-reset days-listing months-listing" :action="$module['has_done_url']" selected="{{ $entry->has_done_physical_activity === 'no' }}" @click="showActivityDetails = false" />
         </div>
       </div>
     </div>
@@ -35,7 +35,7 @@
         <p>{{ __('What type of activity?') }}</p>
         <div class="flex flex-wrap justify-center gap-2">
           @foreach ($module['activity_types'] as $option)
-            <x-form x-target="physical-activity-container notifications physical-activity-reset" :action="$module['activity_type_url']" method="put">
+            <x-form x-target="physical-activity-container notifications physical-activity-reset days-listing months-listing" :action="$module['activity_type_url']" method="put">
               <input type="hidden" name="activity_type" value="{{ $option['value'] }}" />
               <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} cursor-pointer rounded-lg border border-gray-200 px-3 py-2 hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">
                 {{ $option['label'] }}
@@ -51,7 +51,7 @@
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
           @foreach ($module['activity_intensities'] as $option)
             <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-              <x-form x-target="physical-activity-container notifications physical-activity-reset" :action="$module['activity_intensity_url']" method="put">
+              <x-form x-target="physical-activity-container notifications physical-activity-reset days-listing months-listing" :action="$module['activity_intensity_url']" method="put">
                 <input type="hidden" name="activity_intensity" value="{{ $option['value'] }}" />
                 <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                   {{ $option['label'] }}

--- a/resources/views/app/journal/entry/partials/sleep.blade.php
+++ b/resources/views/app/journal/entry/partials/sleep.blade.php
@@ -4,7 +4,7 @@
   <x-slot:action>
     <div id="reset">
       @if ($module['display_reset'])
-        <x-form x-target="sleep-container notifications reset" :action="$module['reset_url']" method="put">
+        <x-form x-target="sleep-container notifications reset days-listing months-listing" :action="$module['reset_url']" method="put">
           <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
             {{ __('Reset') }}
           </button>
@@ -30,7 +30,7 @@
       <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
         @foreach ($module['bedtime'] as $option)
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-            <x-form x-target="sleep-container notifications reset" :action="$module['bedtime_update_url']" method="put" class="h-full">
+            <x-form x-target="sleep-container notifications reset days-listing months-listing" :action="$module['bedtime_update_url']" method="put" class="h-full">
               <input type="hidden" name="bedtime" value="{{ $option['time'] }}" />
               <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                 {{ \App\Helpers\TimeHelper::format($option['time']) }}
@@ -57,7 +57,7 @@
       <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
         @foreach ($module['wake_up_time'] as $option)
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-            <x-form x-target="sleep-container notifications reset" :action="$module['wake_up_time_update_url']" method="put" class="h-full">
+            <x-form x-target="sleep-container notifications reset days-listing months-listing" :action="$module['wake_up_time_update_url']" method="put" class="h-full">
               <input type="hidden" name="wake_up_time" value="{{ $option['time'] }}" />
               <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                 {{ \App\Helpers\TimeHelper::format($option['time']) }}

--- a/resources/views/app/journal/entry/partials/travel.blade.php
+++ b/resources/views/app/journal/entry/partials/travel.blade.php
@@ -4,7 +4,7 @@
   <x-slot:action>
     <div id="travel-reset">
       @if ($module['display_reset'])
-        <x-form x-target="travel-container notifications travel-reset" :action="$module['reset_url']" method="put">
+        <x-form x-target="travel-container notifications travel-reset days-listing months-listing" :action="$module['reset_url']" method="put">
           <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
             {{ __('Reset') }}
           </button>
@@ -22,8 +22,8 @@
       <div class="space-y-2">
         <p>{{ __('Have you traveled today?') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-          <x-button.yes name="has_traveled" value="yes" x-target="travel-container notifications travel-reset" :action="$module['has_traveled_url']" selected="{{ $entry->has_traveled_today === 'yes' }}" @click="showTravelDetails = true" />
-          <x-button.no name="has_traveled" value="no" x-target="travel-container notifications travel-reset" :action="$module['has_traveled_url']" selected="{{ $entry->has_traveled_today === 'no' }}" @click="showTravelDetails = false" />
+          <x-button.yes name="has_traveled" value="yes" x-target="travel-container notifications travel-reset days-listing months-listing" :action="$module['has_traveled_url']" selected="{{ $entry->has_traveled_today === 'yes' }}" @click="showTravelDetails = true" />
+          <x-button.no name="has_traveled" value="no" x-target="travel-container notifications travel-reset days-listing months-listing" :action="$module['has_traveled_url']" selected="{{ $entry->has_traveled_today === 'no' }}" @click="showTravelDetails = false" />
         </div>
       </div>
 
@@ -31,7 +31,7 @@
         <!-- Travel mode -->
         <div class="space-y-2">
           <p>{{ __('How did you travel?') }}</p>
-          <x-form x-target="travel-container notifications travel-reset" :action="$module['travel_mode_url']" method="put" id="travel-mode-form">
+          <x-form x-target="travel-container notifications travel-reset days-listing months-listing" :action="$module['travel_mode_url']" method="put" id="travel-mode-form">
             <div class="grid grid-cols-4 gap-2">
               @foreach ($module['travel_modes'] as $option)
                 <label class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex cursor-pointer items-center justify-center rounded-lg border border-gray-200 p-2 text-center hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">

--- a/resources/views/app/journal/entry/partials/work.blade.php
+++ b/resources/views/app/journal/entry/partials/work.blade.php
@@ -4,7 +4,7 @@
   <x-slot:action>
     <div id="work-reset">
       @if ($module['display_reset'])
-        <x-form x-target="work-container notifications work-reset" :action="$module['reset_url']" method="put">
+        <x-form x-target="work-container notifications work-reset days-listing months-listing" :action="$module['reset_url']" method="put">
           <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
             {{ __('Reset') }}
           </button>
@@ -22,7 +22,7 @@
         <p>{{ __('Have you worked today?') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-            <x-form x-target="work-container notifications work-reset" :action="$module['has_worked_url']" method="put" class="h-full">
+            <x-form x-target="work-container notifications work-reset days-listing months-listing" :action="$module['has_worked_url']" method="put" class="h-full">
               <input type="hidden" name="worked" value="yes" />
               <button @click="showWorkDetails = true" type="submit" class="{{ $entry->worked === 'yes' ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center first:rounded-l-lg last:rounded-r-lg hover:bg-green-50 dark:hover:bg-green-900/40">
                 {{ __('Yes') }}
@@ -30,7 +30,7 @@
             </x-form>
           </div>
           <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-            <x-form x-target="work-container notifications work-reset" :action="$module['has_worked_url']" method="put" class="h-full">
+            <x-form x-target="work-container notifications work-reset days-listing months-listing" :action="$module['has_worked_url']" method="put" class="h-full">
               <input type="hidden" name="worked" value="no" />
               <button @click="showWorkDetails = false" type="submit" class="{{ $entry->worked === 'no' ? 'bg-red-50 font-bold dark:bg-red-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center first:rounded-l-lg last:rounded-r-lg hover:bg-red-50 dark:hover:bg-red-900/40">
                 {{ __('No') }}
@@ -47,7 +47,7 @@
           <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
             @foreach ($module['work_modes'] as $option)
               <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-                <x-form x-target="work-container notifications work-reset" :action="$module['work_mode_url']" method="put" class="h-full">
+                <x-form x-target="work-container notifications work-reset days-listing months-listing" :action="$module['work_mode_url']" method="put" class="h-full">
                   <input type="hidden" name="work_mode" value="{{ $option['value'] }}" />
                   <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                     {{ $option['label'] }}
@@ -64,7 +64,7 @@
           <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
             @foreach ($module['work_loads'] as $option)
               <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-                <x-form x-target="work-container notifications work-reset" :action="$module['work_load_url']" method="put" class="h-full">
+                <x-form x-target="work-container notifications work-reset days-listing months-listing" :action="$module['work_load_url']" method="put" class="h-full">
                   <input type="hidden" name="work_load" value="{{ $option['value'] }}" />
                   <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                     {{ $option['label'] }}
@@ -79,8 +79,8 @@
         <div class="space-y-2">
           <p>{{ __('Did you procrastinate (be honest)?') }}</p>
           <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-            <x-button.yes name="work_procrastinated" value="yes" x-target="work-container notifications work-reset" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'yes' }}" />
-            <x-button.no name="work_procrastinated" value="no" x-target="work-container notifications work-reset" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'no' }}" />
+            <x-button.yes name="work_procrastinated" value="yes" x-target="work-container notifications work-reset days-listing months-listing" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'yes' }}" />
+            <x-button.no name="work_procrastinated" value="no" x-target="work-container notifications work-reset days-listing months-listing" :action="$module['work_procrastinated_url']" selected="{{ $entry->work_procrastinated === 'no' }}" />
           </div>
         </div>
       </div>

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -8,6 +8,7 @@
     ['label' => $journal->name]
   ]" />
 
+  <!-- list of years -->
   @if (count($years) > 1)
     <div id="years-listing" class="bg-white dark:bg-gray-900">
       <div class="mx-auto grid divide-x divide-gray-200 border-b border-gray-200 dark:divide-gray-700 dark:border-gray-700" style="grid-template-columns: repeat({{ count($years) }}, minmax(0, 1fr))">
@@ -21,6 +22,7 @@
     </div>
   @endif
 
+  <!-- list of months -->
   <div id="months-listing" class="bg-white dark:bg-gray-900">
     <div class="mx-auto grid grid-cols-12 divide-x divide-gray-200 border-b border-gray-200 dark:divide-gray-700 dark:border-gray-700">
       @foreach ($months as $month)
@@ -33,6 +35,7 @@
     </div>
   </div>
 
+  <!-- list of days -->
   <div id="days-listing" class="bg-white dark:bg-gray-900">
     <div class="days-grid-{{ $days->count() }} mx-auto grid divide-x divide-gray-200 dark:divide-gray-700">
       @foreach ($days as $day)

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -42,7 +42,7 @@
         <div class="group {{ $day->is_selected ? 'border-b-indigo-200 bg-indigo-50 dark:border-b-indigo-400/60 dark:bg-indigo-900/40' : '' }} {{ $day->is_today ? 'bg-indigo-50 dark:bg-indigo-900/40' : '' }} relative aspect-square cursor-pointer border-b border-gray-200 text-center transition-colors hover:bg-indigo-50 dark:border-gray-700 dark:hover:bg-indigo-900/40">
           <a href="{{ $day->url }}" data-turbo="false" class="flex h-full flex-col items-center justify-center">
             <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $day->day }}</span>
-            <div class="{{ $day->has_blocks === true ? 'bg-green-500' : 'bg-transparent' }} mt-1 h-1.5 w-1.5 rounded-full"></div>
+            <div class="{{ $day->has_content === true ? 'bg-green-500' : 'bg-transparent' }} mt-1 h-1.5 w-1.5 rounded-full"></div>
           </a>
         </div>
       @endforeach

--- a/tests/Unit/Actions/LogActivityIntensityTest.php
+++ b/tests/Unit/Actions/LogActivityIntensityTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\LogActivityIntensity;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class LogActivityIntensityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_logs_activity_intensity_with_light(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_intensity' => null,
+        ]);
+
+        $result = (new LogActivityIntensity(
+            user: $user,
+            entry: $entry,
+            activityIntensity: 'light',
+        ))->execute();
+
+        $this->assertEquals('light', $result->activity_intensity);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_intensity_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_intensity_with_moderate(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_intensity' => null,
+        ]);
+
+        $result = (new LogActivityIntensity(
+            user: $user,
+            entry: $entry,
+            activityIntensity: 'moderate',
+        ))->execute();
+
+        $this->assertEquals('moderate', $result->activity_intensity);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_intensity_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_intensity_with_intense(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_intensity' => null,
+        ]);
+
+        $result = (new LogActivityIntensity(
+            user: $user,
+            entry: $entry,
+            activityIntensity: 'intense',
+        ))->execute();
+
+        $this->assertEquals('intense', $result->activity_intensity);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_intensity_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_journal_does_not_belong_to_user(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Journal entry not found');
+
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $journal = Journal::factory()->for($otherUser)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new LogActivityIntensity(
+            user: $user,
+            entry: $entry,
+            activityIntensity: 'light',
+        ))->execute();
+    }
+
+    #[Test]
+    public function it_throws_when_activity_intensity_is_invalid(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new LogActivityIntensity(
+            user: $user,
+            entry: $entry,
+            activityIntensity: 'invalid',
+        ))->execute();
+    }
+}

--- a/tests/Unit/Actions/LogActivityTypeTest.php
+++ b/tests/Unit/Actions/LogActivityTypeTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\LogActivityType;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class LogActivityTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_logs_activity_type_with_running(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_type' => null,
+        ]);
+
+        $result = (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'running',
+        ))->execute();
+
+        $this->assertEquals('running', $result->activity_type);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_type_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_type_with_cycling(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_type' => null,
+        ]);
+
+        $result = (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'cycling',
+        ))->execute();
+
+        $this->assertEquals('cycling', $result->activity_type);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_type_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_type_with_swimming(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_type' => null,
+        ]);
+
+        $result = (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'swimming',
+        ))->execute();
+
+        $this->assertEquals('swimming', $result->activity_type);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_type_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_type_with_gym(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_type' => null,
+        ]);
+
+        $result = (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'gym',
+        ))->execute();
+
+        $this->assertEquals('gym', $result->activity_type);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_type_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_activity_type_with_walking(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'activity_type' => null,
+        ]);
+
+        $result = (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'walking',
+        ))->execute();
+
+        $this->assertEquals('walking', $result->activity_type);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'activity_type_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_journal_does_not_belong_to_user(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Journal entry not found');
+
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $journal = Journal::factory()->for($otherUser)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'running',
+        ))->execute();
+    }
+
+    #[Test]
+    public function it_throws_when_activity_type_is_invalid(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new LogActivityType(
+            user: $user,
+            entry: $entry,
+            activityType: 'invalid',
+        ))->execute();
+    }
+}

--- a/tests/Unit/Actions/LogActivityTypeTest.php
+++ b/tests/Unit/Actions/LogActivityTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogActivityType;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -55,6 +56,14 @@ final class LogActivityTypeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -89,6 +98,14 @@ final class LogActivityTypeTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }
@@ -127,6 +144,14 @@ final class LogActivityTypeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -163,6 +188,14 @@ final class LogActivityTypeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -197,6 +230,14 @@ final class LogActivityTypeTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogBedTimeTest.php
+++ b/tests/Unit/Actions/LogBedTimeTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions;
 
 use App\Actions\LogBedTime;
 use App\Jobs\CalculateSleepDuration;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -61,6 +62,14 @@ final class LogBedTimeTest extends TestCase
             queue: 'low',
             job: CalculateSleepDuration::class,
             callback: function (CalculateSleepDuration $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
                 return $job->entry->id === $entry->id;
             },
         );

--- a/tests/Unit/Actions/LogHasWorkedTest.php
+++ b/tests/Unit/Actions/LogHasWorkedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogHasWorked;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -55,6 +56,14 @@ final class LogHasWorkedTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -89,6 +98,14 @@ final class LogHasWorkedTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogTravelModeTest.php
+++ b/tests/Unit/Actions/LogTravelModeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogTravelMode;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -57,6 +58,14 @@ final class LogTravelModeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -107,6 +116,14 @@ final class LogTravelModeTest extends TestCase
 
         $this->assertEquals($allModes, $result->travel_mode);
         $this->assertCount(8, $result->travel_mode);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]

--- a/tests/Unit/Actions/LogTravelledTodayTest.php
+++ b/tests/Unit/Actions/LogTravelledTodayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogTravelledToday;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -57,6 +58,14 @@ final class LogTravelledTodayTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -93,6 +102,14 @@ final class LogTravelledTodayTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogTypeOfDayTest.php
+++ b/tests/Unit/Actions/LogTypeOfDayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogTypeOfDay;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -55,6 +56,14 @@ final class LogTypeOfDayTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -89,6 +98,14 @@ final class LogTypeOfDayTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }
@@ -127,6 +144,14 @@ final class LogTypeOfDayTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -163,6 +188,14 @@ final class LogTypeOfDayTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -197,6 +230,14 @@ final class LogTypeOfDayTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogWakeUpTimeTest.php
+++ b/tests/Unit/Actions/LogWakeUpTimeTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions;
 
 use App\Actions\LogWakeUpTime;
 use App\Jobs\CalculateSleepDuration;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -61,6 +62,14 @@ final class LogWakeUpTimeTest extends TestCase
             queue: 'low',
             job: CalculateSleepDuration::class,
             callback: function (CalculateSleepDuration $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
                 return $job->entry->id === $entry->id;
             },
         );

--- a/tests/Unit/Actions/LogWorkLoadTest.php
+++ b/tests/Unit/Actions/LogWorkLoadTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogWorkLoad;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -55,6 +56,14 @@ final class LogWorkLoadTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -91,6 +100,14 @@ final class LogWorkLoadTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -125,6 +142,14 @@ final class LogWorkLoadTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogWorkModeTest.php
+++ b/tests/Unit/Actions/LogWorkModeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogWorkMode;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -55,6 +56,14 @@ final class LogWorkModeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -91,6 +100,14 @@ final class LogWorkModeTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -125,6 +142,14 @@ final class LogWorkModeTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/LogWorkProcrastinatedTest.php
+++ b/tests/Unit/Actions/LogWorkProcrastinatedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\LogWorkProcrastinated;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -58,6 +59,14 @@ final class LogWorkProcrastinatedTest extends TestCase
                 return $job->user->id === $user->id;
             },
         );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
     }
 
     #[Test]
@@ -95,6 +104,14 @@ final class LogWorkProcrastinatedTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/ResetDayTypeDataTest.php
+++ b/tests/Unit/Actions/ResetDayTypeDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\ResetDayTypeData;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -58,6 +59,14 @@ final class ResetDayTypeDataTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/ResetPhysicalActivityDataTest.php
+++ b/tests/Unit/Actions/ResetPhysicalActivityDataTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\ResetPhysicalActivityData;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ResetPhysicalActivityDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_physical_activity_data_for_a_journal_entry(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->for($user)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'has_done_physical_activity' => 'yes',
+            'activity_type' => 'running',
+            'activity_intensity' => 'high',
+        ]);
+
+        $result = (new ResetPhysicalActivityData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+
+        $this->assertNull($result->has_done_physical_activity);
+        $this->assertNull($result->activity_type);
+        $this->assertNull($result->activity_intensity);
+
+        $this->assertDatabaseHas('journal_entries', [
+            'id' => $entry->id,
+            'has_done_physical_activity' => null,
+            'activity_type' => null,
+            'activity_intensity' => null,
+        ]);
+
+        $this->assertInstanceOf(JournalEntry::class, $result);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'physical_activity_reset' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_entry_does_not_belong_to_user(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Journal entry not found');
+
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $journal = Journal::factory()->for($otherUser)->create();
+        $entry = JournalEntry::factory()->for($journal)->create();
+
+        (new ResetPhysicalActivityData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+    }
+}

--- a/tests/Unit/Actions/ResetSleepDataTest.php
+++ b/tests/Unit/Actions/ResetSleepDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\ResetSleepData;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -64,6 +65,14 @@ final class ResetSleepDataTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/ResetTravelDataTest.php
+++ b/tests/Unit/Actions/ResetTravelDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\ResetTravelData;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -61,6 +62,14 @@ final class ResetTravelDataTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Actions/ResetWorkDataTest.php
+++ b/tests/Unit/Actions/ResetWorkDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\ResetWorkData;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -67,6 +68,14 @@ final class ResetWorkDataTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
             },
         );
     }

--- a/tests/Unit/Helpers/JournalHelperTest.php
+++ b/tests/Unit/Helpers/JournalHelperTest.php
@@ -95,4 +95,134 @@ final class JournalHelperTest extends TestCase
             'url' => env('APP_URL') . '/journals/' . $journal->slug . '/entries/2023/2/1',
         ], $collection[2]);
     }
+
+    #[Test]
+    public function it_gets_all_days_in_a_given_month(): void
+    {
+        Carbon::setTestNow(Carbon::create(2023, 2, 15));
+        $journal = Journal::factory()->create();
+
+        // Create entries for Feb 2023, only some with content
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 2,
+            'day' => 5,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 2,
+            'day' => 10,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 2,
+            'day' => 20,
+            'has_content' => false,
+        ]);
+
+        $days = JournalHelper::getDaysInMonth(
+            journal: $journal,
+            year: 2023,
+            month: 2,
+            day: 15,
+        );
+
+        // February 2023 has 28 days
+        $this->assertCount(28, $days);
+
+        // Check day 5 has content
+        $this->assertEquals((object) [
+            'day' => 5,
+            'is_today' => false,
+            'is_selected' => false,
+            'has_content' => true,
+            'url' => env('APP_URL') . '/journals/' . $journal->slug . '/entries/2023/2/5',
+        ], $days[5]);
+
+        // Check day 10 has content
+        $this->assertTrue($days[10]->has_content);
+
+        // Check day 15 is selected and is today but has no content
+        $this->assertTrue($days[15]->is_selected);
+        $this->assertTrue($days[15]->is_today);
+        $this->assertFalse($days[15]->has_content);
+
+        // Check day 20 has no content (has_content is false)
+        $this->assertFalse($days[20]->has_content);
+
+        // Check random day without entry has no content
+        $this->assertFalse($days[25]->has_content);
+    }
+
+    #[Test]
+    public function it_correctly_identifies_days_with_content_across_month(): void
+    {
+        $journal = Journal::factory()->create();
+
+        // Create multiple entries with content
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 3,
+            'day' => 1,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 3,
+            'day' => 15,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 3,
+            'day' => 31,
+            'has_content' => true,
+        ]);
+
+        $days = JournalHelper::getDaysInMonth(
+            journal: $journal,
+            year: 2024,
+            month: 3,
+            day: 1,
+        );
+
+        // March has 31 days
+        $this->assertCount(31, $days);
+
+        // Only days 1, 15, and 31 should have content
+        $this->assertTrue($days[1]->has_content);
+        $this->assertFalse($days[2]->has_content);
+        $this->assertTrue($days[15]->has_content);
+        $this->assertFalse($days[16]->has_content);
+        $this->assertTrue($days[31]->has_content);
+    }
+
+    #[Test]
+    public function it_returns_all_days_without_content_when_no_entries_exist(): void
+    {
+        $journal = Journal::factory()->create();
+
+        $days = JournalHelper::getDaysInMonth(
+            journal: $journal,
+            year: 2023,
+            month: 1,
+            day: 1,
+        );
+
+        // January has 31 days
+        $this->assertCount(31, $days);
+
+        // No day should have content
+        foreach ($days as $day) {
+            $this->assertFalse($day->has_content);
+        }
+    }
 }

--- a/tests/Unit/Helpers/JournalHelperTest.php
+++ b/tests/Unit/Helpers/JournalHelperTest.php
@@ -97,6 +97,124 @@ final class JournalHelperTest extends TestCase
     }
 
     #[Test]
+    public function it_counts_entries_with_content_for_each_month(): void
+    {
+        $journal = Journal::factory()->create();
+
+        // Create entries with content in different months
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 1,
+            'day' => 1,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 1,
+            'day' => 15,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 1,
+            'day' => 20,
+            'has_content' => false,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 3,
+            'day' => 10,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 3,
+            'day' => 20,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 3,
+            'day' => 25,
+            'has_content' => true,
+        ]);
+
+        $collection = JournalHelper::getMonths(
+            journal: $journal,
+            year: 2023,
+            selectedMonth: 1,
+        );
+
+        // January should have 2 entries with content
+        $this->assertEquals(2, $collection[1]->entries_count);
+
+        // February should have 0 entries with content
+        $this->assertEquals(0, $collection[2]->entries_count);
+
+        // March should have 3 entries with content
+        $this->assertEquals(3, $collection[3]->entries_count);
+
+        // All other months should have 0
+        $this->assertEquals(0, $collection[4]->entries_count);
+        $this->assertEquals(0, $collection[12]->entries_count);
+    }
+
+    #[Test]
+    public function it_does_not_count_entries_from_different_years(): void
+    {
+        $journal = Journal::factory()->create();
+
+        // Create entries in 2023
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2023,
+            'month' => 1,
+            'day' => 1,
+            'has_content' => true,
+        ]);
+
+        // Create entries in 2024
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 1,
+            'day' => 1,
+            'has_content' => true,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 1,
+            'day' => 15,
+            'has_content' => true,
+        ]);
+
+        $collection2023 = JournalHelper::getMonths(
+            journal: $journal,
+            year: 2023,
+            selectedMonth: 1,
+        );
+
+        $collection2024 = JournalHelper::getMonths(
+            journal: $journal,
+            year: 2024,
+            selectedMonth: 1,
+        );
+
+        // 2023 January should have 1 entry
+        $this->assertEquals(1, $collection2023[1]->entries_count);
+
+        // 2024 January should have 2 entries
+        $this->assertEquals(2, $collection2024[1]->entries_count);
+    }
+
+    #[Test]
     public function it_gets_all_days_in_a_given_month(): void
     {
         Carbon::setTestNow(Carbon::create(2023, 2, 15));

--- a/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
+++ b/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CheckPresenceOfContentInJournalEntryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_sets_has_content_to_false_when_all_fields_are_null(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => true,
+            'bedtime' => null,
+            'wake_up_time' => null,
+            'sleep_duration_in_minutes' => null,
+            'worked' => null,
+            'work_mode' => null,
+            'work_load' => null,
+            'work_procrastinated' => null,
+            'has_traveled_today' => null,
+            'travel_details' => null,
+            'travel_mode' => null,
+            'day_type' => null,
+            'has_done_physical_activity' => null,
+            'activity_type' => null,
+            'activity_intensity' => null,
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertFalse($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_bedtime_is_set(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+            'bedtime' => '22:30',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_worked_is_set(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+            'worked' => 'yes',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_day_type_is_set(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+            'day_type' => 'workday',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_physical_activity_is_set(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+            'has_done_physical_activity' => 'yes',
+            'activity_type' => 'running',
+            'activity_intensity' => 'moderate',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_travel_mode_is_set(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+            'has_traveled_today' => 'yes',
+            'travel_mode' => ['car', 'plane'],
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **New Feature**: Added automatic content presence tracking for journal entries via a new `has_content` boolean field
- **Database**: Added `has_content` column to `journal_entries` table (default: false)
- **New Job**: `CheckPresenceOfContentInJournalEntry` job automatically detects and updates content presence by scanning entry fields
- **Action Integration**: All logging and reset actions now trigger content presence checks on the low queue:
  - Logging actions: LogActivityIntensity, LogActivityType, LogBedTime, LogHasWorked, LogWorkMode, LogTravelMode, LogTravelledToday, LogTypeOfDay, LogWakeUpTime, LogWorkLoad, LogWorkProcrastinated
  - Reset actions: ResetDayTypeData, ResetPhysicalActivityData, ResetSleepData, ResetTravelData, ResetWorkData
- **Helper Updates**: JournalHelper now uses `has_content` flag and provides per-month entry counts for days with content
- **UI Enhancements**: Updated form targets across journal entry views (day_type, physical_activity, sleep, travel, work partials) to refresh both day and month listings
- **View Logic**: Changed day indicator (green dot) from `has_blocks` to `has_content` in journal entry display
- **Test Coverage**: Comprehensive unit tests added for the new job, all action classes, helpers, and content presence detection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->