### PR TITLE
docs: add docs basics for developers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# JournalOS Developer Docs
+
+Welcome, fellow journal whisperer. This folder is the front door for contributors who want to ship features without shipping chaos.
+
+Start here: [Coding guidelines](coding-guidelines.md) for how we like to build.
+
+## Architecture in 60 seconds
+
+JournalOS is a Laravel 12 monolith with three faces: web app, API, and marketing site. Core behavior lives in **Actions** (one user intent per class), view data is shaped by **Presenters**, and the UI is server-rendered with Blade. AlpineJS sprinkles interactivity; Tailwind handles styling. Background work rides the `low` queue.
+
+## Languages & stack
+
+- **PHP 8.4** with Laravel 12 for the application backbone.
+- **Blade** templates for server-rendered views.
+- **AlpineJS + Alpine Ajax** for light interactivity.
+- **Tailwind CSS v4** for styling.
+
+No heavyweight JS framework by design. The goal: fast pages, simple mental model, fewer moving parts.
+
+## Why this architecture
+
+- **Actions** keep business behavior small, testable, and easy to reuse.
+- **Presenters** keep views clean by preparing data ahead of time.
+- **Laravel-first** patterns mean onboarding is quick for PHP devs.
+- **Monolith** keeps deployment, data, and performance predictable.
+
+## Directory tour
+
+- `app/Actions/` — single-responsibility classes that represent user actions.
+- `app/View/Presenters/` — view-focused data preparation.
+- `app/Http/Controllers/` — request handling and inline validation.
+- `app/Models/` — Eloquent models and relationships.
+- `app/Jobs/` — queued work (mostly `low` priority).
+- `app/Mail/` — mailables.
+- `app/Console/` — Artisan commands.
+- `app/Helpers/` — shared helpers.
+- `bootstrap/` — application bootstrapping and middleware registration.
+- `config/` — configuration files.
+- `database/` — migrations, factories, seeders.
+- `public/` — front controller and public assets.
+- `resources/` — Blade views, CSS, front-end assets.
+- `routes/` — route files for web, API, auth, marketing, console.
+- `tests/` — PHPUnit tests (controllers in `tests/Feature/Controllers`).
+- `docs/` — you are here. Keep it tidy.
+
+## Where to look first
+
+- For behavior: `app/Actions/`
+- For screens: `resources/views/`
+- For data flow to views: `app/View/Presenters/`
+- For routes: `routes/*.php`
+
+Happy shipping.

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -1,0 +1,94 @@
+# Coding Guidelines (JournalOS Flavor)
+
+This is the “how we build” guide for contributors. It’s based on repository config and the code you’ll actually touch. Follow it and you’ll blend in like a local.
+
+## The big ideas
+
+- **Actions are the unit of behavior.** One user intent per class in `app/Actions/`.
+- **Presenters shape view data.** See `app/View/Presenters/`.
+- **Controllers stay thin.** They orchestrate requests, run validation inline, and call Actions.
+- **Queues are mostly `low`.** When dispatching jobs, use `->onQueue('low')` unless there’s a strong reason not to.
+- **No heavy JS frameworks.** Blade + AlpineJS + Alpine Ajax + Tailwind v4 is the stack.
+
+## PHP conventions (Laravel + this repo’s house rules)
+
+- **PSR-12 baseline.** The repo enforces it via Pint and general code style.
+- **4-space indentation in PHP.** (From `.editorconfig`.)
+- **Always declare strict types.** The codebase expects `declare(strict_types=1);`.
+- **Type hints everywhere.** Add parameter and return types. Prefer explicit types over PHPDoc.
+- **Constructor promotion.** Use PHP 8 constructor property promotion; no empty `__construct()`.
+- **Use curly braces** for control structures, even one-liners.
+- **Prefer `final` / `readonly`** where appropriate. Presenters follow this pattern.
+- **No Form Requests.** Use inline validation inside controllers instead.
+- **Avoid new dependencies** unless explicitly approved.
+
+## Validation & requests
+
+- Controllers use inline validation (`$request->validate([...])`).
+- Follow existing validation styles (array-based rules are common in this codebase).
+
+## Actions
+
+- Every user action is a dedicated class in `app/Actions/`.
+- Keep Actions small, focused, and reusable.
+- Many Actions dispatch background jobs; use the `low` queue unless you have a strong reason.
+
+## Presenters
+
+- Presenters in `app/View/Presenters/` build view-ready structures.
+- They’re typically `final readonly` and return arrays/collections ready for Blade.
+- Keep display logic out of Blade whenever possible.
+
+## Jobs & queues
+
+- Use queued jobs for expensive work (`app/Jobs/`).
+- Default to `->onQueue('low')` for dispatches, consistent with the codebase.
+
+## Eloquent & data
+
+- Prefer Eloquent relationships and query builder patterns.
+- Avoid direct `DB::` calls unless necessary.
+- Use factories for test data (`database/factories/`).
+
+## Frontend conventions
+
+- **Blade** is the UI layer (`resources/views/`).
+- **Tailwind CSS v4** only; avoid deprecated v3 utilities.
+- **AlpineJS** handles interactivity. Keep it light and purposeful.
+
+## Formatting & linting
+
+**EditorConfig** (`.editorconfig`):
+- PHP: 4 spaces.
+- Blade / JS / CSS / JSON: 2 spaces.
+- Markdown: do not trim trailing whitespace.
+
+**Pint** (`pint.json`):
+- Strict types, global namespace imports, `final` classes, strict comparisons, ordered class elements, and more.
+- Run `vendor/bin/pint --dirty` before finalizing changes.
+
+**Prettier** (`.prettierrc`):
+- 2-space indentation.
+- Single quotes.
+- Trailing commas where possible.
+- Blade parser enabled with `prettier-plugin-blade` and Tailwind class sorting.
+
+**Static analysis**:
+- `phpstan.neon` targets `app/`, `routes/`, and `database/` at level 5.
+- `rector.php` enables Laravel-focused refactors and type improvements.
+
+## Testing expectations
+
+- Use PHPUnit.
+- **Controllers tests** live in `tests/Feature/Controllers/`.
+- Everything else goes in `tests/Unit/` following the same structure as the source.
+- After tests pass, run `composer journalos:unit`.
+
+## Where to look for examples
+
+- Actions: `app/Actions/` (single responsibility, queues, helpers).
+- Presenters: `app/View/Presenters/` (`final readonly`, view-friendly data).
+- Controllers: `app/Http/Controllers/` (inline validation + actions).
+- Jobs: `app/Jobs/` (low queue usage).
+
+When in doubt: follow the existing patterns. This app is calm, consistent, and allergic to cleverness.


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable set of coding guidelines so contributors follow project conventions consistently.
- Capture repository-driven conventions (Actions, Presenters, queue usage, Blade + Alpine + Tailwind) and formatting expectations.
- Make linting and static-analysis guidance explicit to reduce PR feedback and align contributions with tooling.
- Surface where to look first and concrete examples so new contributors can onboard faster.

### Description

- Added `docs/coding-guidelines.md` with PHP/Laravel house rules, queue conventions, presenter/action guidance, frontend and testing expectations.
- Updated `docs/README.md` to include a `Start here: [Coding guidelines](coding-guidelines.md)` link for discoverability.
- Derived the rules from repository configuration and files including `.editorconfig`, `pint.json`, `phpstan.neon`, `rector.php`, and `.prettierrc` to ensure consistency.
- Changes are limited to the `docs/` directory and do not modify runtime application code.

### Testing

- Ran `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` was not found in the environment.
- Ran `php artisan test tests/Unit/Models/LogTest.php`, which failed due to missing `vendor/autoload.php` (dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf2f4d6f483208ca6bf0741ec1b02)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added comprehensive coding guidelines document (`docs/coding-guidelines.md`) covering project conventions for PHP/Laravel standards, validation styles, action/presenter/controller responsibilities, queue usage, frontend stack, and testing expectations
- Updated developer documentation (`docs/README.md`) with direct link to coding guidelines for improved discoverability
- Guidelines derived from repository configuration files (`.editorconfig`, `pint.json`, `phpstan.neon`, `rector.php`, `.prettierrc`) to ensure alignment with project tooling
- Documentation-only changes; no modifications to application code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->