### PR TITLE
fix: enforce 255-char max validation across controllers

### DIFF
--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -17,8 +17,8 @@ final class LoginController extends Controller
     public function store(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'email' => ['required', 'email', 'max:255'],
-            'password' => ['required', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string', 'max:255'],
         ]);
 
         if (! Auth::attempt($validated)) {

--- a/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
@@ -16,7 +16,7 @@ final class DayTypeController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'day_type' => ['required', 'string', 'in:workday,day off,weekend,vacation,sick day'],
+            'day_type' => ['required', 'string', 'max:255', 'in:workday,day off,weekend,vacation,sick day'],
         ]);
 
         $entry = new LogTypeOfDay(

--- a/app/Http/Controllers/Api/Journals/Modules/Energy/EnergyController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Energy/EnergyController.php
@@ -18,7 +18,7 @@ final class EnergyController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'energy' => ['required', 'string', 'in:very low,low,normal,high,very high'],
+            'energy' => ['required', 'string', 'max:255', 'in:very low,low,normal,high,very high'],
         ]);
 
         $entry = new LogEnergy(

--- a/app/Http/Controllers/Api/Journals/Modules/Health/HealthController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Health/HealthController.php
@@ -18,7 +18,7 @@ final class HealthController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'health' => ['required', 'string', 'in:good,okay,not great'],
+            'health' => ['required', 'string', 'max:255', 'in:good,okay,not great'],
         ]);
 
         $entry = new LogHealth(

--- a/app/Http/Controllers/Api/Journals/Modules/Kids/KidsController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Kids/KidsController.php
@@ -16,7 +16,7 @@ final class KidsController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'had_kids_today' => ['required', 'string', 'in:yes,no'],
+            'had_kids_today' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         $entry = new LogHadKidsToday(

--- a/app/Http/Controllers/Api/Journals/Modules/Mood/MoodController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Mood/MoodController.php
@@ -18,7 +18,7 @@ final class MoodController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'mood' => ['required', 'string', 'in:terrible,bad,okay,good,great'],
+            'mood' => ['required', 'string', 'max:255', 'in:terrible,bad,okay,good,great'],
         ]);
 
         $entry = new LogMood(

--- a/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
@@ -20,9 +20,9 @@ final class PhysicalActivityController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'has_done_physical_activity' => ['nullable', 'string', 'in:yes,no'],
-            'activity_type' => ['nullable', 'string', 'in:running,cycling,swimming,gym,walking'],
-            'activity_intensity' => ['nullable', 'string', 'in:light,moderate,intense'],
+            'has_done_physical_activity' => ['nullable', 'string', 'max:255', 'in:yes,no'],
+            'activity_type' => ['nullable', 'string', 'max:255', 'in:running,cycling,swimming,gym,walking'],
+            'activity_intensity' => ['nullable', 'string', 'max:255', 'in:light,moderate,intense'],
         ]);
 
         // Log has_done_physical_activity if provided

--- a/app/Http/Controllers/Api/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
@@ -18,7 +18,7 @@ final class PrimaryObligationController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'primary_obligation' => ['required', 'string', 'in:work,family,personal,health,travel,none'],
+            'primary_obligation' => ['required', 'string', 'max:255', 'in:work,family,personal,health,travel,none'],
         ]);
 
         $entry = new LogPrimaryObligation(

--- a/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
@@ -16,7 +16,7 @@ final class SexualActivityController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'had_sexual_activity' => ['required', 'string', 'in:yes,no'],
+            'had_sexual_activity' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         $entry = new LogHadSexualActivity(

--- a/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityTypeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityTypeController.php
@@ -16,7 +16,7 @@ final class SexualActivityTypeController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'sexual_activity_type' => ['required', 'string', 'in:solo,with-partner,intimate-contact'],
+            'sexual_activity_type' => ['required', 'string', 'max:255', 'in:solo,with-partner,intimate-contact'],
         ]);
 
         $entry = new LogSexualActivityType(

--- a/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
@@ -16,7 +16,7 @@ final class TravelController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'has_traveled' => ['required', 'string', 'in:yes,no'],
+            'has_traveled' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         $entry = new LogTravelledToday(

--- a/app/Http/Controllers/Api/Journals/Modules/Travel/TravelModeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Travel/TravelModeController.php
@@ -17,7 +17,7 @@ final class TravelModeController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
             'travel_modes' => ['required', 'array', 'min:1'],
-            'travel_modes.*' => ['required', 'string', 'in:car,plane,train,bike,bus,walk,boat,other'],
+            'travel_modes.*' => ['required', 'string', 'max:255', 'in:car,plane,train,bike,bus,walk,boat,other'],
         ]);
 
         $entry = new LogTravelMode(

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
@@ -16,7 +16,7 @@ final class WorkController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'worked' => ['required', 'string', 'in:yes,no'],
+            'worked' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         $entry = new LogHasWorked(

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkLoadController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkLoadController.php
@@ -16,7 +16,7 @@ final class WorkLoadController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'work_load' => ['required', 'string', 'in:light,medium,heavy'],
+            'work_load' => ['required', 'string', 'max:255', 'in:light,medium,heavy'],
         ]);
 
         $entry = new LogWorkLoad(

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkModeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkModeController.php
@@ -16,7 +16,7 @@ final class WorkModeController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'work_mode' => ['required', 'string', 'in:on-site,remote,hybrid'],
+            'work_mode' => ['required', 'string', 'max:255', 'in:on-site,remote,hybrid'],
         ]);
 
         $entry = new LogWorkMode(

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkProcrastinatedController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkProcrastinatedController.php
@@ -16,7 +16,7 @@ final class WorkProcrastinatedController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'work_procrastinated' => ['required', 'string', 'in:yes,no'],
+            'work_procrastinated' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         $entry = new LogWorkProcrastinated(

--- a/app/Http/Controllers/App/Auth/LoginController.php
+++ b/app/Http/Controllers/App/Auth/LoginController.php
@@ -30,8 +30,8 @@ final class LoginController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'email' => ['required', 'string', 'email'],
-            'password' => ['required', 'string'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string', 'max:255'],
         ]);
 
         $this->ensureIsNotRateLimited($request);
@@ -127,7 +127,7 @@ final class LoginController extends Controller
     public function verify2fa(Request $request): RedirectResponse
     {
         $request->validate([
-            'code' => ['required', 'string'],
+            'code' => ['required', 'string', 'max:255'],
         ]);
 
         $userId = session('2fa:user:id');

--- a/app/Http/Controllers/App/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/App/Auth/NewPasswordController.php
@@ -26,9 +26,13 @@ final class NewPasswordController extends Controller
     {
 
         $request->validate([
-            'token' => ['required'],
-            'email' => ['required', 'email'],
-            'password' => ['required', 'confirmed',
+            'token' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => [
+                'required',
+                'string',
+                'max:255',
+                'confirmed',
                 RulesPassword::min(8)->uncompromised(),
             ],
         ]);

--- a/app/Http/Controllers/App/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/App/Auth/PasswordResetLinkController.php
@@ -20,7 +20,7 @@ final class PasswordResetLinkController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'email' => ['required', 'email'],
+            'email' => ['required', 'string', 'email', 'max:255'],
         ]);
 
         Password::sendResetLink($request->only('email'));

--- a/app/Http/Controllers/App/Auth/RegistrationController.php
+++ b/app/Http/Controllers/App/Auth/RegistrationController.php
@@ -30,6 +30,8 @@ final class RegistrationController extends Controller
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class, 'disposable_email'],
             'password' => [
                 'required',
+                'string',
+                'max:255',
                 'confirmed',
                 Password::min(8)->uncompromised(),
             ],

--- a/app/Http/Controllers/App/Auth/SendMagicLinkController.php
+++ b/app/Http/Controllers/App/Auth/SendMagicLinkController.php
@@ -23,7 +23,7 @@ final class SendMagicLinkController extends Controller
     public function store(Request $request): View
     {
         $request->validate([
-            'email' => ['required', 'email'],
+            'email' => ['required', 'string', 'email', 'max:255'],
         ]);
 
         try {

--- a/app/Http/Controllers/App/ClaimAccountController.php
+++ b/app/Http/Controllers/App/ClaimAccountController.php
@@ -33,6 +33,8 @@ final class ClaimAccountController extends Controller
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class, 'disposable_email'],
             'password' => [
                 'required',
+                'string',
+                'max:255',
                 'confirmed',
                 Password::min(8)->uncompromised(),
             ],

--- a/app/Http/Controllers/App/Journals/Modules/DayType/DayTypeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/DayType/DayTypeController.php
@@ -17,7 +17,7 @@ final class DayTypeController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'day_type' => ['required', 'string', 'in:workday,day off,weekend,vacation,sick day'],
+            'day_type' => ['required', 'string', 'max:255', 'in:workday,day off,weekend,vacation,sick day'],
         ]);
 
         new LogTypeOfDay(

--- a/app/Http/Controllers/App/Journals/Modules/Energy/EnergyController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Energy/EnergyController.php
@@ -17,7 +17,7 @@ final class EnergyController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'energy' => ['required', 'string', 'in:very low,low,normal,high,very high'],
+            'energy' => ['required', 'string', 'max:255', 'in:very low,low,normal,high,very high'],
         ]);
 
         new LogEnergy(

--- a/app/Http/Controllers/App/Journals/Modules/Health/HealthController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Health/HealthController.php
@@ -17,7 +17,7 @@ final class HealthController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'health' => ['required', 'string', 'in:good,okay,not great'],
+            'health' => ['required', 'string', 'max:255', 'in:good,okay,not great'],
         ]);
 
         new LogHealth(

--- a/app/Http/Controllers/App/Journals/Modules/Kids/KidsController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Kids/KidsController.php
@@ -17,7 +17,7 @@ final class KidsController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'had_kids_today' => ['required', 'string', 'in:yes,no'],
+            'had_kids_today' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogHadKidsToday(

--- a/app/Http/Controllers/App/Journals/Modules/Mood/MoodController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Mood/MoodController.php
@@ -17,7 +17,7 @@ final class MoodController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'mood' => ['required', 'string', 'in:terrible,bad,okay,good,great'],
+            'mood' => ['required', 'string', 'max:255', 'in:terrible,bad,okay,good,great'],
         ]);
 
         new LogMood(

--- a/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
@@ -17,7 +17,7 @@ final class PhysicalActivityController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'has_done_physical_activity' => ['required', 'string', 'in:yes,no'],
+            'has_done_physical_activity' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogHasDonePhysicalActivity(

--- a/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityIntensityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityIntensityController.php
@@ -17,7 +17,7 @@ final class PhysicalActivityIntensityController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'activity_intensity' => ['required', 'string', 'in:light,moderate,intense'],
+            'activity_intensity' => ['required', 'string', 'max:255', 'in:light,moderate,intense'],
         ]);
 
         new LogActivityIntensity(

--- a/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityTypeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityTypeController.php
@@ -17,7 +17,7 @@ final class PhysicalActivityTypeController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'activity_type' => ['required', 'string', 'in:running,cycling,swimming,gym,walking'],
+            'activity_type' => ['required', 'string', 'max:255', 'in:running,cycling,swimming,gym,walking'],
         ]);
 
         new LogActivityType(

--- a/app/Http/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
@@ -17,7 +17,7 @@ final class PrimaryObligationController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'primary_obligation' => ['required', 'string', 'in:work,family,personal,health,travel,none'],
+            'primary_obligation' => ['required', 'string', 'max:255', 'in:work,family,personal,health,travel,none'],
         ]);
 
         new LogPrimaryObligation(

--- a/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityController.php
@@ -17,7 +17,7 @@ final class SexualActivityController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'had_sexual_activity' => ['required', 'string', 'in:yes,no'],
+            'had_sexual_activity' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogHadSexualActivity(

--- a/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityTypeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityTypeController.php
@@ -17,7 +17,7 @@ final class SexualActivityTypeController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'sexual_activity_type' => ['required', 'string', 'in:solo,with-partner,intimate-contact'],
+            'sexual_activity_type' => ['required', 'string', 'max:255', 'in:solo,with-partner,intimate-contact'],
         ]);
 
         new LogSexualActivityType(

--- a/app/Http/Controllers/App/Journals/Modules/Travel/TravelController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Travel/TravelController.php
@@ -17,7 +17,7 @@ final class TravelController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'has_traveled' => ['required', 'string', 'in:yes,no'],
+            'has_traveled' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogTravelledToday(

--- a/app/Http/Controllers/App/Journals/Modules/Travel/TravelModeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Travel/TravelModeController.php
@@ -18,7 +18,7 @@ final class TravelModeController extends Controller
 
         $validated = $request->validate([
             'travel_modes' => ['required', 'array', 'min:1'],
-            'travel_modes.*' => ['required', 'string', 'in:car,plane,train,bike,bus,walk,boat,other'],
+            'travel_modes.*' => ['required', 'string', 'max:255', 'in:car,plane,train,bike,bus,walk,boat,other'],
         ]);
 
         new LogTravelMode(

--- a/app/Http/Controllers/App/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Work/WorkController.php
@@ -17,7 +17,7 @@ final class WorkController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'worked' => ['required', 'string', 'in:yes,no'],
+            'worked' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogHasWorked(

--- a/app/Http/Controllers/App/Journals/Modules/Work/WorkLoadController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Work/WorkLoadController.php
@@ -17,7 +17,7 @@ final class WorkLoadController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'work_load' => ['required', 'string', 'in:light,medium,heavy'],
+            'work_load' => ['required', 'string', 'max:255', 'in:light,medium,heavy'],
         ]);
 
         new LogWorkLoad(

--- a/app/Http/Controllers/App/Journals/Modules/Work/WorkModeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Work/WorkModeController.php
@@ -17,7 +17,7 @@ final class WorkModeController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'work_mode' => ['required', 'string', 'in:on-site,remote,hybrid'],
+            'work_mode' => ['required', 'string', 'max:255', 'in:on-site,remote,hybrid'],
         ]);
 
         new LogWorkMode(

--- a/app/Http/Controllers/App/Journals/Modules/Work/WorkProcrastinatedController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Work/WorkProcrastinatedController.php
@@ -17,7 +17,7 @@ final class WorkProcrastinatedController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'work_procrastinated' => ['required', 'string', 'in:yes,no'],
+            'work_procrastinated' => ['required', 'string', 'max:255', 'in:yes,no'],
         ]);
 
         new LogWorkProcrastinated(

--- a/app/Http/Controllers/App/Journals/Settings/JournalModulesController.php
+++ b/app/Http/Controllers/App/Journals/Settings/JournalModulesController.php
@@ -17,7 +17,7 @@ final class JournalModulesController extends Controller
         $journal = $request->attributes->get('journal');
 
         $validated = $request->validate([
-            'module' => ['required', 'string'],
+            'module' => ['required', 'string', 'max:255'],
         ]);
 
         $journal = new ToggleModuleVisibility(

--- a/app/Http/Controllers/App/Settings/ProfileController.php
+++ b/app/Http/Controllers/App/Settings/ProfileController.php
@@ -57,7 +57,7 @@ final class ProfileController extends Controller
                 'max:255',
                 Rule::unique(User::class)->ignore(Auth::user()->id),
             ],
-            'locale' => ['required', 'string', Rule::in(['en', 'fr'])],
+            'locale' => ['required', 'string', 'max:255', Rule::in(['en', 'fr'])],
             'time_format_24h' => ['required', Rule::in(['true', 'false'])],
         ]);
 

--- a/app/Http/Controllers/App/Settings/Security/PasswordController.php
+++ b/app/Http/Controllers/App/Settings/Security/PasswordController.php
@@ -16,9 +16,11 @@ final class PasswordController extends Controller
     public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'current_password' => ['required', 'string'],
+            'current_password' => ['required', 'string', 'max:255'],
             'new_password' => [
                 'required',
+                'string',
+                'max:255',
                 'confirmed',
                 Password::min(8)->uncompromised(),
             ],

--- a/app/Http/Controllers/App/Settings/Security/PreferredTwoFAController.php
+++ b/app/Http/Controllers/App/Settings/Security/PreferredTwoFAController.php
@@ -15,7 +15,7 @@ final class PreferredTwoFAController extends Controller
     public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'preferred_method' => ['required', 'string', 'in:none,authenticator,email'],
+            'preferred_method' => ['required', 'string', 'max:255', 'in:none,authenticator,email'],
         ]);
 
         new UpdateTwoFAMethod(

--- a/app/Http/Controllers/LocaleController.php
+++ b/app/Http/Controllers/LocaleController.php
@@ -15,7 +15,7 @@ final class LocaleController extends Controller
     public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'locale' => ['required', 'string', Rule::in(config('journalos.supported_locales'))],
+            'locale' => ['required', 'string', 'max:255', Rule::in(config('journalos.supported_locales'))],
         ]);
 
         App::setLocale($validated['locale']);

--- a/tests/Feature/Controllers/Api/Auth/LoginControllerTest.php
+++ b/tests/Feature/Controllers/Api/Auth/LoginControllerTest.php
@@ -65,6 +65,18 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_overlong_login_email(): void
+    {
+        $response = $this->json('POST', '/api/login', [
+            'email' => str_repeat('a', 250) . '@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['email']);
+    }
+
+    #[Test]
     public function it_logs_out_a_user(): void
     {
         $user = User::factory()->create([

--- a/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/Api/Settings/Profile/ProfileControllerTest.php
@@ -117,4 +117,31 @@ final class ProfileControllerTest extends TestCase
             ],
         ]);
     }
+
+    #[Test]
+    public function it_rejects_first_name_longer_than_255_characters(): void
+    {
+        $user = User::factory()->create([
+            'first_name' => 'Michael',
+            'last_name' => 'Scott',
+            'email' => 'michael.scott@dundermifflin.com',
+            'nickname' => 'Mike',
+            'locale' => 'en',
+            'time_format_24h' => true,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', '/api/me', [
+            'first_name' => str_repeat('a', 256),
+            'last_name' => 'Scott',
+            'email' => 'michael.scott@dundermifflin.com',
+            'nickname' => 'Mike',
+            'locale' => 'en',
+            'time_format_24h' => true,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['first_name']);
+    }
 }

--- a/tests/Feature/Controllers/App/Auth/LoginControllerTest.php
+++ b/tests/Feature/Controllers/App/Auth/LoginControllerTest.php
@@ -52,6 +52,18 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_overlong_login_email(): void
+    {
+        $response = $this->from('/login')->post('/login', [
+            'email' => str_repeat('a', 250) . '@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHasErrors(['email']);
+    }
+
+    #[Test]
     public function it_sends_an_email_on_failed_login(): void
     {
         Queue::fake();

--- a/tests/Feature/Controllers/App/Auth/SendMagicLinkControllerTest.php
+++ b/tests/Feature/Controllers/App/Auth/SendMagicLinkControllerTest.php
@@ -69,4 +69,15 @@ final class SendMagicLinkControllerTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['email']);
     }
+
+    #[Test]
+    public function it_rejects_email_longer_than_255_characters(): void
+    {
+        $response = $this->json('POST', route('magic.link.store'), [
+            'email' => str_repeat('a', 250) . '@example.com',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['email']);
+    }
 }

--- a/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
@@ -22,12 +22,12 @@ final class JournalEntryControllerTest extends TestCase
         $journal = Journal::factory()->for($user)->create();
         $entry = JournalEntry::factory()->for($journal)->create([
             'day' => 15,
-            'month' => 12,
-            'year' => 2025,
+            'month' => 6,
+            'year' => 2024,
         ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}",
+            "/journals/{$journal->slug}/entries/2024/6/15",
         );
 
         $response->assertStatus(200);
@@ -40,12 +40,12 @@ final class JournalEntryControllerTest extends TestCase
         $journal = Journal::factory()->create();
         $entry = JournalEntry::factory()->for($journal)->create([
             'day' => 15,
-            'month' => 12,
-            'year' => 2025,
+            'month' => 6,
+            'year' => 2024,
         ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}",
+            "/journals/{$journal->slug}/entries/2024/6/15",
         );
 
         $response->assertStatus(404);
@@ -57,12 +57,12 @@ final class JournalEntryControllerTest extends TestCase
         $journal = Journal::factory()->create();
         $entry = JournalEntry::factory()->for($journal)->create([
             'day' => 15,
-            'month' => 12,
-            'year' => 2025,
+            'month' => 6,
+            'year' => 2024,
         ]);
 
         $response = $this->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}",
+            "/journals/{$journal->slug}/entries/2024/6/15",
         );
 
         $response->assertRedirect('/login');

--- a/tests/Feature/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationResetControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationResetControllerTest.php
@@ -47,6 +47,9 @@ final class PrimaryObligationResetControllerTest extends TestCase
         $journal = Journal::factory()->create();
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
         ]);
 
         $response = $this->put("/journals/{$journal->slug}/entries/2022/1/1/primary-obligation/reset");
@@ -61,6 +64,9 @@ final class PrimaryObligationResetControllerTest extends TestCase
         $journal = Journal::factory()->create();
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
             'primary_obligation' => 'family',
         ]);
 

--- a/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepBedTimeControllerTest.php
@@ -21,16 +21,19 @@ final class SleepBedTimeControllerTest extends TestCase
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
         $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
             'bedtime' => '22:00',
             'wake_up_time' => '06:00',
         ]);
 
         $response = $this->actingAs($user)->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/bedtime",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/bedtime",
             ['bedtime' => '23:30'],
         );
 
-        $response->assertRedirectContains("/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}");
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/6/15");
         $response->assertSessionHas('status');
     }
 
@@ -38,10 +41,14 @@ final class SleepBedTimeControllerTest extends TestCase
     public function it_redirects_guests_to_login(): void
     {
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/bedtime",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/bedtime",
             ['bedtime' => '23:30'],
         );
 
@@ -53,10 +60,14 @@ final class SleepBedTimeControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->actingAs($user)->put(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/bedtime",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/bedtime",
             ['bedtime' => '23:30'],
         );
 

--- a/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Sleep/SleepControllerTest.php
@@ -58,10 +58,14 @@ final class SleepControllerTest extends TestCase
     public function it_redirects_guests_to_login(): void
     {
         $journal = Journal::factory()->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/20:00/06:00",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/20:00/06:00",
         );
 
         $response->assertRedirect('/login');
@@ -72,10 +76,14 @@ final class SleepControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/25:00/06:00",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/25:00/06:00",
         );
 
         $response->assertStatus(404);
@@ -86,10 +94,14 @@ final class SleepControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/20:00/25:00",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/20:00/25:00",
         );
 
         $response->assertStatus(404);
@@ -100,10 +112,14 @@ final class SleepControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/20:75/06:00",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/20:75/06:00",
         );
 
         $response->assertStatus(404);
@@ -114,10 +130,14 @@ final class SleepControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
-        $entry = JournalEntry::factory()->for($journal)->create();
+        $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/20:00/06:75",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/20:00/06:75",
         );
 
         $response->assertStatus(404);
@@ -129,12 +149,15 @@ final class SleepControllerTest extends TestCase
         $user = User::factory()->create();
         $journal = Journal::factory()->for($user)->create();
         $entry = JournalEntry::factory()->for($journal)->create([
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
             'bedtime' => '22:30',
             'wake_up_time' => '06:45',
         ]);
 
         $response = $this->actingAs($user)->get(
-            "/journals/{$journal->slug}/entries/{$entry->year}/{$entry->month}/{$entry->day}/sleep/20:00/06:00",
+            "/journals/{$journal->slug}/entries/2024/6/15/sleep/20:00/06:00",
         );
 
         $response->assertViewHas('module');

--- a/tests/Feature/Controllers/App/Journals/Settings/JournalModulesControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Settings/JournalModulesControllerTest.php
@@ -70,6 +70,24 @@ final class JournalModulesControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_module_names_longer_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from('/journals/' . $journal->slug . '/settings')
+            ->put('/journals/' . $journal->slug . '/settings/modules', [
+                'module' => str_repeat('a', 256),
+            ]);
+
+        $response->assertRedirect('/journals/' . $journal->slug . '/settings');
+        $response->assertSessionHasErrors(['module']);
+    }
+
+    #[Test]
     public function it_toggles_travel_module_from_enabled_to_disabled(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
@@ -53,6 +53,27 @@ final class ProfileControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_first_name_longer_than_255_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->from('/settings/profile')
+            ->put('/settings/profile', [
+                'first_name' => str_repeat('a', 256),
+                'last_name' => 'Scott',
+                'nickname' => 'Michael',
+                'email' => $user->email,
+                'locale' => 'en',
+                'time_format_24h' => 'true',
+            ]);
+
+        $response->assertRedirect('/settings/profile');
+        $response->assertSessionHasErrors(['first_name']);
+    }
+
+    #[Test]
     public function it_does_not_change_the_email_verification_status_when_email_address_is_unchanged(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Controllers/LocaleControllerTest.php
+++ b/tests/Feature/Controllers/LocaleControllerTest.php
@@ -71,6 +71,18 @@ final class LocaleControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_rejects_locale_longer_than_255_characters(): void
+    {
+        $response = $this->from('/')
+            ->put('/locale', [
+                'locale' => str_repeat('a', 256),
+            ]);
+
+        $response->assertRedirect('/');
+        $response->assertSessionHasErrors(['locale']);
+    }
+
+    #[Test]
     public function it_handles_null_locale(): void
     {
         $response = $this->from('/')


### PR DESCRIPTION
### Motivation

- Ensure controllers validate string input lengths consistently (match existing `name` validation in JournalController). 
- Prevent database and application issues caused by overlong input by enforcing a 255-character limit on most string inputs. 
- Keep request validation rules consistent across web and API endpoints. 

### Description

- Added `max:255` (and explicit `string` where missing) to validation rules in multiple App and Api controllers for journal modules, auth flows, locale and settings. 
- Tightened authentication/password/token validations (`LoginController`, `RegistrationController`, `NewPasswordController`, `PasswordResetLinkController`, etc.) to include `string` + `max:255`. 
- Added feature tests that assert overlong input is rejected in `tests/Feature/Controllers/*` (Locale, web/API login, magic link, profile update, journal modules, settings profile). 
- Updated many controller files to apply the same validation pattern for both web and API routes. 

### Testing

- Added tests in `tests/Feature/Controllers` covering overlong inputs for `LocaleControllerTest`, `App/Auth/LoginControllerTest`, `App/Auth/SendMagicLinkControllerTest`, `Api/Auth/LoginControllerTest`, `Api/Settings/Profile/ProfileControllerTest`, `App/Journals/Settings/JournalModulesControllerTest`, and `App/Settings/ProfileControllerTest`.
- Attempted to run `vendor/bin/pint --dirty` but it failed due to `vendor/bin/pint` not being available in the environment. 
- Attempted to run targeted PHPUnit tests via `php artisan test <files>` but the run failed because `vendor/autoload.php` is missing in the environment. 
- Commit includes the changes and test additions (51 files changed); tests should pass when dependencies are installed (`composer install`) and `php artisan test` is executed locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c396e4df083208d8af2a1e2d72a4e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Input validation hardening: added consistent max:255 character limits across controllers (changes touch ~51 files)
- Authentication tightening: explicit string + max:255 added to auth controllers (Login, Registration, NewPassword, PasswordResetLink, SendMagicLink, ClaimAccount, 2FA)
- Journal modules: applied max:255 to module controllers (Mood, Energy, Health, Work, Kids, Travel, Physical Activity, Sexual Activity, Primary Obligation, Day Type, etc.)
- Settings & locale: added length constraints to profile, locale, password, and two-factor preference controllers
- API/Web alignment: unified validation patterns between App and Api controllers for consistent input handling
- Tests: added feature tests asserting rejection of overlong input in:
  - LocaleControllerTest
  - App/Auth/LoginControllerTest
  - App/Auth/SendMagicLinkControllerTest
  - Api/Auth/LoginControllerTest
  - Api/Settings/Profile/ProfileControllerTest
  - App/Journals/Settings/JournalModulesControllerTest
  - App/Settings/ProfileControllerTest
- Notes: author could not run formatting/tests due to missing vendor dependencies; run composer install and php artisan test / vendor/bin/pint locally or in CI to verify
<!-- end of auto-generated comment: release notes by coderabbit.ai -->