### PR TITLE
feat: delete journal and related data

### DIFF
--- a/app/Actions/DestroyJournal.php
+++ b/app/Actions/DestroyJournal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\DeleteRelatedJournalData;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -21,6 +22,7 @@ final readonly class DestroyJournal
     {
         $this->validate();
         $this->delete();
+        $this->deleteRelatedData();
         $this->log();
         $this->updateUserLastActivityDate();
     }
@@ -35,6 +37,11 @@ final readonly class DestroyJournal
     private function delete(): void
     {
         $this->journal->delete();
+    }
+
+    private function deleteRelatedData(): void
+    {
+        DeleteRelatedJournalData::dispatch($this->journal->id)->onQueue('low');
     }
 
     private function log(): void

--- a/app/Jobs/DeleteRelatedJournalData.php
+++ b/app/Jobs/DeleteRelatedJournalData.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class DeleteRelatedJournalData implements ShouldQueue
+{
+    use Queueable;
+
+    private const int BATCH_SIZE = 1000;
+
+    /**
+     * Add every table that has a journal_entry_id FK here.
+     */
+    private const array ENTRY_RELATED_TABLES = [
+        'book_journal_entry' => 'journal_entry_id',
+        'module_sleep' => 'journal_entry_id',
+        'module_work' => 'journal_entry_id',
+        'module_travel' => 'journal_entry_id',
+        'module_health' => 'journal_entry_id',
+        'module_mood' => 'journal_entry_id',
+        'module_day_type' => 'journal_entry_id',
+        'module_physical_activity' => 'journal_entry_id',
+    ];
+
+    public function __construct(
+        public int $journalId,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->deleteJournalEntriesAndModules();
+        $this->deleteLogs();
+    }
+
+    private function deleteJournalEntriesAndModules(): void
+    {
+        DB::table('journal_entries')
+            ->where('journal_id', $this->journalId)
+            ->select('id')
+            ->orderedChunkById(
+                self::BATCH_SIZE,
+                function (Collection $rows): void {
+                    $entryIds = $rows->pluck('id')->all();
+
+                    DB::transaction(function () use ($entryIds): void {
+                        foreach (self::ENTRY_RELATED_TABLES as $table => $fkColumn) {
+                            DB::table($table)
+                                ->whereIn($fkColumn, $entryIds)
+                                ->delete();
+                        }
+
+                        DB::table('journal_entries')
+                            ->whereIn('id', $entryIds)
+                            ->delete();
+                    });
+                },
+                column: 'id',
+            );
+    }
+
+    private function deleteLogs(): void
+    {
+        DB::table('logs')
+            ->where('journal_id', $this->journalId)
+            ->select('id')
+            ->orderedChunkById(
+                self::BATCH_SIZE,
+                function (Collection $rows): void {
+                    $logIds = $rows->pluck('id')->all();
+
+                    DB::transaction(function () use ($logIds): void {
+                        DB::table('logs')
+                            ->whereIn('id', $logIds)
+                            ->delete();
+                    });
+                },
+                column: 'id',
+            );
+    }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "prettier-plugin-blade": "^2.1.21",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18",
-        "vite": "^7.3.0",
+        "vite": "^7.3.1",
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.54.0",

--- a/database/migrations/2025_07_21_114648_create_journals_table.php
+++ b/database/migrations/2025_07_21_114648_create_journals_table.php
@@ -30,7 +30,7 @@ return new class extends Migration {
             $table->boolean('show_sexual_activity_module')->default(false);
             $table->boolean('show_social_density_module')->default(true);
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,151 +2,151 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/energy</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/health</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/kids</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/mood</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/social-density</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/primary-obligation</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sexual-activity</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-07T20:52:27+00:00</lastmod>
+    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>

--- a/tests/Unit/Actions/DestroyJournalTest.php
+++ b/tests/Unit/Actions/DestroyJournalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Actions;
 
 use App\Actions\DestroyJournal;
+use App\Jobs\DeleteRelatedJournalData;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Journal;
@@ -57,6 +58,14 @@ final class DestroyJournalTest extends TestCase
             job: UpdateUserLastActivityDate::class,
             callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
                 return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: DeleteRelatedJournalData::class,
+            callback: function (DeleteRelatedJournalData $job) use ($journal): bool {
+                return $job->journalId === $journal->id;
             },
         );
     }

--- a/tests/Unit/Jobs/DeleteRelatedJournalDataTest.php
+++ b/tests/Unit/Jobs/DeleteRelatedJournalDataTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\DeleteRelatedJournalData;
+use App\Models\Book;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\Log;
+use App\Models\ModuleDayType;
+use App\Models\ModuleHealth;
+use App\Models\ModuleMood;
+use App\Models\ModulePhysicalActivity;
+use App\Models\ModuleSleep;
+use App\Models\ModuleTravel;
+use App\Models\ModuleWork;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DeleteRelatedJournalDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_deletes_journal_entries_and_all_related_data(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        ModuleSleep::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleWork::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleTravel::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleHealth::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleMood::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleDayType::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModulePhysicalActivity::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+
+        $book = Book::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry->books()->attach($book, ['status' => 'reading']);
+
+        $job = new DeleteRelatedJournalData($journal->id);
+        $job->handle();
+
+        $this->assertDatabaseMissing('journal_entries', [
+            'id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_sleep', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_work', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_travel', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_health', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_mood', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_day_type', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_physical_activity', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('book_journal_entry', [
+            'journal_entry_id' => $entry->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_logs_for_the_journal(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $log = Log::factory()->create([
+            'user_id' => $user->id,
+            'journal_id' => $journal->id,
+        ]);
+
+        $job = new DeleteRelatedJournalData($journal->id);
+        $job->handle();
+
+        $this->assertDatabaseMissing('logs', [
+            'id' => $log->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_handles_multiple_journal_entries(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $entries = JournalEntry::factory()->count(5)->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        foreach ($entries as $entry) {
+            ModuleSleep::factory()->create([
+                'journal_entry_id' => $entry->id,
+            ]);
+            ModuleWork::factory()->create([
+                'journal_entry_id' => $entry->id,
+            ]);
+        }
+
+        $job = new DeleteRelatedJournalData($journal->id);
+        $job->handle();
+
+        foreach ($entries as $entry) {
+            $this->assertDatabaseMissing('journal_entries', [
+                'id' => $entry->id,
+            ]);
+            $this->assertDatabaseMissing('module_sleep', [
+                'journal_entry_id' => $entry->id,
+            ]);
+            $this->assertDatabaseMissing('module_work', [
+                'journal_entry_id' => $entry->id,
+            ]);
+        }
+    }
+
+    #[Test]
+    public function it_does_not_delete_data_from_other_journals(): void
+    {
+        $user = User::factory()->create();
+        $journal1 = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $journal2 = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $entry1 = JournalEntry::factory()->create([
+            'journal_id' => $journal1->id,
+        ]);
+        $entry2 = JournalEntry::factory()->create([
+            'journal_id' => $journal2->id,
+        ]);
+
+        ModuleSleep::factory()->create([
+            'journal_entry_id' => $entry1->id,
+        ]);
+        ModuleSleep::factory()->create([
+            'journal_entry_id' => $entry2->id,
+        ]);
+
+        $log1 = Log::factory()->create([
+            'user_id' => $user->id,
+            'journal_id' => $journal1->id,
+        ]);
+        $log2 = Log::factory()->create([
+            'user_id' => $user->id,
+            'journal_id' => $journal2->id,
+        ]);
+
+        $job = new DeleteRelatedJournalData($journal1->id);
+        $job->handle();
+
+        $this->assertDatabaseMissing('journal_entries', [
+            'id' => $entry1->id,
+        ]);
+        $this->assertDatabaseHas('journal_entries', [
+            'id' => $entry2->id,
+        ]);
+        $this->assertDatabaseMissing('module_sleep', [
+            'journal_entry_id' => $entry1->id,
+        ]);
+        $this->assertDatabaseHas('module_sleep', [
+            'journal_entry_id' => $entry2->id,
+        ]);
+        $this->assertDatabaseMissing('logs', [
+            'id' => $log1->id,
+        ]);
+        $this->assertDatabaseHas('logs', [
+            'id' => $log2->id,
+        ]);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **New Feature**: Journal deletion now properly removes all related data including journal entries, logs, and associated module data (sleep, work, travel, health, mood, day type, physical activity records)
- **Performance**: Related data deletion is processed asynchronously via background jobs in batches of 1000 records
- **Database Change**: Removed cascade delete constraint on `journals.user_id` foreign key; deletion now handled explicitly by the application
- **Test Coverage**: Added comprehensive unit tests to verify journal deletion behavior, related data cleanup, and cross-journal data isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->