### PR TITLE
feat: delete account

### DIFF
--- a/app/Actions/DestroyAccount.php
+++ b/app/Actions/DestroyAccount.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Jobs\DeleteRelatedAccountData;
 use App\Mail\AccountDestroyed;
 use App\Models\AccountDeletionReason;
 use App\Models\User;
@@ -22,8 +23,14 @@ final readonly class DestroyAccount
     public function execute(): void
     {
         $this->user->delete();
+        $this->delereteRelatedData();
         $this->sendMail();
         $this->logAccountDeletion();
+    }
+
+    private function delereteRelatedData(): void
+    {
+        DeleteRelatedAccountData::dispatch($this->user->id)->onQueue('low');
     }
 
     private function sendMail(): void

--- a/app/Jobs/DeleteRelatedAccountData.php
+++ b/app/Jobs/DeleteRelatedAccountData.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class DeleteRelatedAccountData implements ShouldQueue
+{
+    use Queueable;
+
+    private const int BATCH_SIZE = 1000;
+
+    /**
+     * Add every table that has a user_id FK here.
+     */
+    private const array USER_RELATED_TABLES = [
+        'books' => 'user_id',
+        'emails_sent' => 'user_id',
+    ];
+
+    public function __construct(
+        public int $userId,
+    ) {}
+
+    public function handle(): void
+    {
+        $this->deleteJournalsAndRelatedData();
+        $this->deleteUserRelatedData();
+        $this->deleteLogs();
+    }
+
+    private function deleteJournalsAndRelatedData(): void
+    {
+        DB::table('journals')
+            ->where('user_id', $this->userId)
+            ->select('id')
+            ->orderedChunkById(
+                self::BATCH_SIZE,
+                function (Collection $rows): void {
+                    $journalIds = $rows->pluck('id')->all();
+
+                    foreach ($journalIds as $journalId) {
+                        DeleteRelatedJournalData::dispatch($journalId)->onQueue('low');
+                    }
+
+                    DB::table('journals')
+                        ->whereIn('id', $journalIds)
+                        ->delete();
+                },
+                column: 'id',
+            );
+    }
+
+    private function deleteUserRelatedData(): void
+    {
+        DB::transaction(function (): void {
+            foreach (self::USER_RELATED_TABLES as $table => $fkColumn) {
+                DB::table($table)
+                    ->where($fkColumn, $this->userId)
+                    ->delete();
+            }
+        });
+    }
+
+    private function deleteLogs(): void
+    {
+        DB::table('logs')
+            ->where('user_id', $this->userId)
+            ->select('id')
+            ->orderedChunkById(
+                self::BATCH_SIZE,
+                function (Collection $rows): void {
+                    $logIds = $rows->pluck('id')->all();
+
+                    DB::transaction(function () use ($logIds): void {
+                        DB::table('logs')
+                            ->whereIn('id', $logIds)
+                            ->delete();
+                    });
+                },
+                column: 'id',
+            );
+    }
+}

--- a/database/migrations/2025_07_22_020018_create_emails_sent_table.php
+++ b/database/migrations/2025_07_22_020018_create_emails_sent_table.php
@@ -24,7 +24,7 @@ return new class extends Migration {
             $table->datetime('delivered_at')->nullable();
             $table->datetime('bounced_at')->nullable();
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/database/migrations/2025_12_04_032752_create_logs_table.php
+++ b/database/migrations/2025_12_04_032752_create_logs_table.php
@@ -20,7 +20,7 @@ return new class extends Migration {
             $table->string('action');
             $table->string('description');
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users');
             $table->foreign('journal_id')->references('id')->on('journals')->onDelete('set null');
         });
     }

--- a/database/migrations/2026_01_04_000001_add_sexual_activity_to_journal_entries.php
+++ b/database/migrations/2026_01_04_000001_add_sexual_activity_to_journal_entries.php
@@ -14,7 +14,7 @@ return new class extends Migration {
     {
         Schema::table('journal_entries', function (Blueprint $table): void {
             $table->text('had_sexual_activity')->nullable();
-            $table->text('sexual_activity_type')->nullable()->after('had_sexual_activity');
+            $table->text('sexual_activity_type')->nullable();
         });
     }
 

--- a/database/migrations/2026_01_04_155722_create_books_table.php
+++ b/database/migrations/2026_01_04_155722_create_books_table.php
@@ -18,7 +18,7 @@ return new class extends Migration {
             $table->text('name');
             $table->string('progress')->nullable();
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/database/migrations/2026_01_06_000001_add_social_density_to_journal_entries.php
+++ b/database/migrations/2026_01_06_000001_add_social_density_to_journal_entries.php
@@ -10,7 +10,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('journal_entries', function (Blueprint $table): void {
-            $table->text('social_density')->nullable()->after('energy');
+            $table->text('social_density')->nullable();
         });
     }
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,151 +2,151 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/energy</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/health</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/kids</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/mood</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/social-density</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/primary-obligation</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sexual-activity</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-07T22:36:11+00:00</lastmod>
+    <lastmod>2026-01-07T23:21:39+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>

--- a/tests/Unit/Jobs/DeleteRelatedAccountDataTest.php
+++ b/tests/Unit/Jobs/DeleteRelatedAccountDataTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\DeleteRelatedAccountData;
+use App\Jobs\DeleteRelatedJournalData;
+use App\Models\Book;
+use App\Models\EmailSent;
+use App\Models\Journal;
+use App\Models\Log;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class DeleteRelatedAccountDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_dispatches_job_to_delete_journal_data(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $job = new DeleteRelatedAccountData($user->id);
+        $job->handle();
+
+        Queue::assertPushed(DeleteRelatedJournalData::class, function ($job) use ($journal) {
+            return $job->journalId === $journal->id;
+        });
+
+        $this->assertDatabaseMissing('journals', [
+            'id' => $journal->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_all_journals_for_the_user(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal1 = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $journal2 = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $job = new DeleteRelatedAccountData($user->id);
+        $job->handle();
+
+        Queue::assertPushed(DeleteRelatedJournalData::class, 2);
+
+        $this->assertDatabaseMissing('journals', [
+            'id' => $journal1->id,
+        ]);
+        $this->assertDatabaseMissing('journals', [
+            'id' => $journal2->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_user_related_data(): void
+    {
+        $user = User::factory()->create();
+        $book = Book::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $emailSent = EmailSent::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $job = new DeleteRelatedAccountData($user->id);
+        $job->handle();
+
+        $this->assertDatabaseMissing('books', [
+            'id' => $book->id,
+        ]);
+        $this->assertDatabaseMissing('emails_sent', [
+            'id' => $emailSent->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_logs_for_the_user(): void
+    {
+        $user = User::factory()->create();
+        $log = Log::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $job = new DeleteRelatedAccountData($user->id);
+        $job->handle();
+
+        $this->assertDatabaseMissing('logs', [
+            'id' => $log->id,
+        ]);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes - Delete Account Feature

- Added asynchronous account deletion that enqueues a background job to remove all user-related data
- Cleanup runs on the low-priority queue to avoid blocking the deletion operation
- Journals and logs processed in batches of 1000 to optimize performance and memory use
- Per-journal cleanup dispatched to dedicated DeleteRelatedJournalData jobs for proper cascade handling
- Deletions of user-related tables (books, emails_sent, etc.) performed inside DB transactions for consistency
- Removed cascade delete from several foreign keys (books, emails_sent, logs) so cleanup is handled explicitly by the job
- Added unit tests verifying job dispatch, journal-job dispatch, journals/books/emails/logs deletion and overall cleanup behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->