### PR TITLE
feat: add module categories

### DIFF
--- a/app/Enums/ModuleType.php
+++ b/app/Enums/ModuleType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ModuleType: string
+{
+    case BODY_HEALTH = 'body and health';
+    case MIND_EMOTION = 'mind and emotion';
+    case WORK_RESPONSABILITIES = 'work and responsibilities';
+    case RELATIONSHIPS_SOCIAL_LIFE = 'relationships and social life';
+    case MOVEMENT_PLACES = 'movement and places';
+}

--- a/app/Models/ModuleDayType.php
+++ b/app/Models/ModuleDayType.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $day_type # Format: 'workday', 'day off', 'weekend', 'vacation', 'sick day'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleDayType extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'day_type',
     ];
 

--- a/app/Models/ModuleEnergy.php
+++ b/app/Models/ModuleEnergy.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $energy # Format: 'very low', 'low', 'normal', 'high', 'very high'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleEnergy extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'energy',
     ];
 

--- a/app/Models/ModuleHealth.php
+++ b/app/Models/ModuleHealth.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $health # Format: 'good', 'okay', 'not great'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleHealth extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'health',
     ];
 

--- a/app/Models/ModuleKids.php
+++ b/app/Models/ModuleKids.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $had_kids_today # Format: 'yes'|'no'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleKids extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'had_kids_today',
     ];
 

--- a/app/Models/ModuleMood.php
+++ b/app/Models/ModuleMood.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $mood # Format: 'terrible', 'bad', 'okay', 'good', 'great'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleMood extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'mood',
     ];
 

--- a/app/Models/ModulePhysicalActivity.php
+++ b/app/Models/ModulePhysicalActivity.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $has_done_physical_activity # Format: 'yes'|'no'
  * @property string|null $activity_type # Format: 'running', 'cycling', 'swimming', 'gym', 'walking'
  * @property string|null $activity_intensity # Format: 'light', 'moderate', 'intense'
@@ -41,6 +42,7 @@ final class ModulePhysicalActivity extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'has_done_physical_activity',
         'activity_type',
         'activity_intensity',

--- a/app/Models/ModulePrimaryObligation.php
+++ b/app/Models/ModulePrimaryObligation.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $primary_obligation # Format: 'work', 'family', 'personal', 'health', 'travel', 'none'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModulePrimaryObligation extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'primary_obligation',
     ];
 

--- a/app/Models/ModuleSexualActivity.php
+++ b/app/Models/ModuleSexualActivity.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $had_sexual_activity # Format: 'yes'|'no'
  * @property string|null $sexual_activity_type # Format: 'solo', 'with-partner', 'intimate-contact'
  * @property Carbon $created_at
@@ -40,6 +41,7 @@ final class ModuleSexualActivity extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'had_sexual_activity',
         'sexual_activity_type',
     ];

--- a/app/Models/ModuleSleep.php
+++ b/app/Models/ModuleSleep.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $bedtime # Format: 'HH:MM'
  * @property string|null $wake_up_time # Format: 'HH:MM'
  * @property string|null $sleep_duration_in_minutes # Format: '420'
@@ -41,6 +42,7 @@ final class ModuleSleep extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'bedtime',
         'wake_up_time',
         'sleep_duration_in_minutes',

--- a/app/Models/ModuleSocialDensity.php
+++ b/app/Models/ModuleSocialDensity.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $social_density # Format: 'alone', 'few people', 'crowd', 'too much'
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
@@ -39,6 +40,7 @@ final class ModuleSocialDensity extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'social_density',
     ];
 

--- a/app/Models/ModuleTravel.php
+++ b/app/Models/ModuleTravel.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $has_traveled_today # Format: 'yes'|'no'
  * @property string|null $travel_details # Format: 'Took a flight to...'
  * @property array<string>|null $travel_mode # Format: ['car',plane,train,bike,bus,walk,boat,other]
@@ -41,6 +42,7 @@ final class ModuleTravel extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'has_traveled_today',
         'travel_details',
         'travel_mode',

--- a/app/Models/ModuleWork.php
+++ b/app/Models/ModuleWork.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id
  * @property int $journal_entry_id
+ * @property string $category # Format: string
  * @property string|null $worked # Format: 'yes'|'no'
  * @property string|null $work_mode # Format: 'on-site'|'remote'|'hybrid'
  * @property string|null $work_load # Format: 'light'|'medium'|'heavy'
@@ -42,6 +43,7 @@ final class ModuleWork extends Model
      */
     protected $fillable = [
         'journal_entry_id',
+        'category',
         'worked',
         'work_mode',
         'work_load',

--- a/database/migrations/2026_01_07_004051_create_module_sleep_table.php
+++ b/database/migrations/2026_01_07_004051_create_module_sleep_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_sleep', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
             $table->text('bedtime')->nullable();
             $table->text('wake_up_time')->nullable();
             $table->text('sleep_duration_in_minutes')->nullable();

--- a/database/migrations/2026_01_08_000000_create_module_work_table.php
+++ b/database/migrations/2026_01_08_000000_create_module_work_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_work', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::WORK_RESPONSABILITIES->value);
             $table->text('worked')->nullable();
             $table->text('work_mode')->nullable();
             $table->text('work_load')->nullable();

--- a/database/migrations/2026_01_08_000001_create_module_health_table.php
+++ b/database/migrations/2026_01_08_000001_create_module_health_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_health', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
             $table->text('health')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_08_000001_create_module_travel_table.php
+++ b/database/migrations/2026_01_08_000001_create_module_travel_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_travel', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::MOVEMENT_PLACES->value);
             $table->text('has_traveled_today')->nullable();
             $table->text('travel_details')->nullable();
             $table->text('travel_mode')->nullable();

--- a/database/migrations/2026_01_08_000002_create_module_physical_activity_table.php
+++ b/database/migrations/2026_01_08_000002_create_module_physical_activity_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_physical_activity', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
             $table->text('has_done_physical_activity')->nullable();
             $table->text('activity_type')->nullable();
             $table->text('activity_intensity')->nullable();

--- a/database/migrations/2026_01_08_001436_create_module_kids_table.php
+++ b/database/migrations/2026_01_08_001436_create_module_kids_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_kids', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::RELATIONSHIPS_SOCIAL_LIFE->value);
             $table->text('had_kids_today')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_08_011202_create_module_primary_obligation_table.php
+++ b/database/migrations/2026_01_08_011202_create_module_primary_obligation_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_primary_obligation', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::WORK_RESPONSABILITIES->value);
             $table->text('primary_obligation')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_08_013533_create_module_social_density_table.php
+++ b/database/migrations/2026_01_08_013533_create_module_social_density_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_social_density', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::RELATIONSHIPS_SOCIAL_LIFE->value);
             $table->text('social_density')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_09_000000_create_module_day_type_table.php
+++ b/database/migrations/2026_01_09_000000_create_module_day_type_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_day_type', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::WORK_RESPONSABILITIES->value);
             $table->text('day_type')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_09_000000_create_module_mood_table.php
+++ b/database/migrations/2026_01_09_000000_create_module_mood_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_mood', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::MIND_EMOTION->value);
             $table->text('mood')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_10_000000_create_module_energy_table.php
+++ b/database/migrations/2026_01_10_000000_create_module_energy_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_energy', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
             $table->text('energy')->nullable();
             $table->timestamps();
             $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');

--- a/database/migrations/2026_01_11_000000_create_module_sexual_activity_table.php
+++ b/database/migrations/2026_01_11_000000_create_module_sexual_activity_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\ModuleType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,7 @@ return new class extends Migration {
         Schema::create('module_sexual_activity', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
             $table->text('had_sexual_activity')->nullable();
             $table->text('sexual_activity_type')->nullable();
             $table->timestamps();

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,151 +2,151 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/energy</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/health</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/kids</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/mood</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/social-density</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/primary-obligation</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sexual-activity</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-08T01:42:59+00:00</lastmod>
+    <lastmod>2026-01-08T03:17:38+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **New `ModuleType` Enum**: Added a new PHP enum with five predefined module categories:
  - Body and Health
  - Mind and Emotion
  - Work and Responsibilities
  - Relationships and Social Life
  - Movement and Places

- **Module Models Updated**: Added `category` property to all module models:
  - ModuleHealth, ModuleWork, ModuleTravel, ModulePhysicalActivity, ModuleKids
  - ModulePrimaryObligation, ModuleSocialDensity, ModuleMood, ModuleEnergy
  - ModuleSexualActivity, ModuleSleep, ModuleDayType
  - All models include the `category` field in their `$fillable` arrays for mass assignment

- **Database Migrations**: Updated all module table migrations to include a `category` string column with sensible defaults based on each module's type:
  - Body/Health modules default to `body and health`
  - Work-related modules default to `work and responsibilities`
  - Social/relationship modules default to `relationships and social life`
  - Movement-related modules default to `movement and places`
  - Mood modules default to `mind and emotion`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->