### PR TITLE
feat: expose journal entry notes in api

### DIFF
--- a/app/Actions/LogNotes.php
+++ b/app/Actions/LogNotes.php
@@ -44,7 +44,7 @@ final readonly class LogNotes
             ['field' => 'notes'],
             ['body' => TextSanitizer::html($this->notes)],
         );
-        $this->entry->touch();
+        $this->entry->refresh()->touch();
         $this->entry->unsetRelation('richTextNotes');
     }
 

--- a/app/Http/Controllers/Api/Journals/Notes/NotesController.php
+++ b/app/Http/Controllers/Api/Journals/Notes/NotesController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Notes;
+
+use App\Actions\LogNotes;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class NotesController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $validated = $request->validate([
+            'notes' => ['required', 'string'],
+        ]);
+
+        $entry = new LogNotes(
+            user: Auth::user(),
+            entry: $entry,
+            notes: $validated['notes'],
+        )->execute();
+
+        return response()->json([
+            'data' => new JournalEntryResource($entry),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/Api/Journals/Notes/NotesController.php
+++ b/app/Http/Controllers/Api/Journals/Notes/NotesController.php
@@ -18,7 +18,7 @@ final class NotesController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'notes' => ['required', 'string'],
+            'notes' => ['required', 'string', 'max:100000'],
         ]);
 
         $entry = new LogNotes(

--- a/app/Http/Controllers/Api/Journals/Notes/NotesResetController.php
+++ b/app/Http/Controllers/Api/Journals/Notes/NotesResetController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Notes;
+
+use App\Actions\ResetNotes;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class NotesResetController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $entry = new ResetNotes(
+            user: Auth::user(),
+            entry: $entry,
+        )->execute();
+
+        return response()->json([
+            'data' => new JournalEntryResource($entry),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/App/Journals/Notes/NotesController.php
+++ b/app/Http/Controllers/App/Journals/Notes/NotesController.php
@@ -29,7 +29,7 @@ final class NotesController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'notes' => ['required', 'string'],
+            'notes' => ['required', 'string', 'max:100000'],
         ]);
 
         new LogNotes(

--- a/app/Http/Middleware/CheckJournalEntryAPI.php
+++ b/app/Http/Middleware/CheckJournalEntryAPI.php
@@ -55,6 +55,7 @@ final class CheckJournalEntryAPI
             'moduleKids',
             'modulePrimaryObligation',
             'moduleSocialDensity',
+            'richTextNotes',
         );
 
         $request->attributes->add(['journal_entry' => $entry]);

--- a/app/Http/Resources/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntryResource.php
@@ -20,6 +20,10 @@ final class JournalEntryResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $richTextNotes = $this->richTextNotes;
+        $notes = $richTextNotes ? mb_trim($richTextNotes->render()) : null;
+        $notes = $richTextNotes && $richTextNotes->toPlainText() === '' ? null : $notes;
+
         return [
             'type' => 'journal_entry',
             'id' => (string) $this->id,
@@ -28,6 +32,7 @@ final class JournalEntryResource extends JsonResource
                 'day' => $this->day,
                 'month' => $this->month,
                 'year' => $this->year,
+                'notes' => $notes,
                 'modules' => [
                     'sleep' => [
                         'bedtime' => $this->moduleSleep?->bedtime,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,9 @@ parameters:
     level: 5
 
     ignoreErrors:
+        -
+            message: '#Call to an undefined method Tonysm\\RichTextLaravel\\Models\\RichText::(render|toPlainText)\(\)\.#'
+            path: app/Http/Resources/JournalEntryResource.php
 
     excludePaths:
         - app/Jobs/SendEmail.php

--- a/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
@@ -6,6 +6,7 @@
   <x-marketing.docs.attribute name="attributes.day" type="integer" description="The day of the journal entry." />
   <x-marketing.docs.attribute name="attributes.month" type="integer" description="The month of the journal entry." />
   <x-marketing.docs.attribute name="attributes.year" type="integer" description="The year of the journal entry." />
+  <x-marketing.docs.attribute name="attributes.notes" type="string" description="The rich text notes for the journal entry, rendered as HTML." />
   <x-marketing.docs.attribute name="attributes.modules" type="object" description="The modules included with the journal entry." />
   <x-marketing.docs.attribute name="attributes.modules.sleep" type="object" description="The sleep module payload." />
   <x-marketing.docs.attribute name="attributes.modules.sleep.bedtime" type="string" description="The bedtime time of the journal entry." />

--- a/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
@@ -31,6 +31,11 @@
   <span class="text-rose-800">2024</span>
   ,
 </div>
+<div class="pl-12">
+  "notes":
+  <span class="text-lime-700">"&lt;p&gt;Notes for the day.&lt;/p&gt;"</span>
+  ,
+</div>
 <div class="pl-12">"modules": {</div>
 <div class="pl-16">"sleep": {</div>
 <div class="pl-20">

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,8 @@ use App\Http\Controllers\Api\Journals\Modules\Work\WorkController;
 use App\Http\Controllers\Api\Journals\Modules\Work\WorkLoadController;
 use App\Http\Controllers\Api\Journals\Modules\Work\WorkModeController;
 use App\Http\Controllers\Api\Journals\Modules\Work\WorkProcrastinatedController;
+use App\Http\Controllers\Api\Journals\Notes\NotesController;
+use App\Http\Controllers\Api\Journals\Notes\NotesResetController;
 use App\Http\Controllers\Api\Settings;
 use App\Http\Controllers\Api\Settings\Account\DestroyAccountController;
 use App\Http\Controllers\Api\Settings\Account\PruneAccountController;
@@ -165,6 +167,18 @@ Route::name('api.')->group(function (): void {
                     ->whereNumber('month')
                     ->whereNumber('day')
                     ->name('journal.entry.social-density.update');
+
+                Route::put('journals/{id}/{year}/{month}/{day}/notes', [NotesController::class, 'update'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.notes.update');
+
+                Route::put('journals/{id}/{year}/{month}/{day}/notes/reset', [NotesResetController::class, 'update'])
+                    ->whereNumber('year')
+                    ->whereNumber('month')
+                    ->whereNumber('day')
+                    ->name('journal.entry.notes.reset');
             });
 
             // settings

--- a/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
@@ -26,6 +26,7 @@ final class JournalEntryControllerTest extends TestCase
                 'day',
                 'month',
                 'year',
+                'notes',
                 'modules' => [
                     'sleep' => [
                         'bedtime',
@@ -62,12 +63,18 @@ final class JournalEntryControllerTest extends TestCase
             'month' => 4,
             'year' => 2025,
         ]);
+        $entry->richTextNotes()->create([
+            'field' => 'notes',
+            'body' => '<p>Notes for the entry.</p>',
+        ]);
         ModuleSleep::factory()->create([
             'journal_entry_id' => $entry->id,
             'bedtime' => '22:30',
             'wake_up_time' => '06:45',
             'sleep_duration_in_minutes' => '495',
         ]);
+        $entry->load('richTextNotes');
+        $expectedNotes = mb_trim($entry->richTextNotes->render());
 
         Sanctum::actingAs($user);
 
@@ -84,6 +91,7 @@ final class JournalEntryControllerTest extends TestCase
                     'day' => 12,
                     'month' => 4,
                     'year' => 2025,
+                    'notes' => $expectedNotes,
                     'modules' => [
                         'sleep' => [
                             'bedtime' => '22:30',

--- a/tests/Feature/Controllers/Api/Journals/Notes/NotesControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Notes/NotesControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Notes;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class NotesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_notes_and_returns_the_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/notes", [
+            'notes' => '<p>Notes for the day.</p>',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                'type',
+                'id',
+                'attributes' => [
+                    'journal_id',
+                    'day',
+                    'month',
+                    'year',
+                    'notes',
+                    'modules',
+                    'created_at',
+                    'updated_at',
+                ],
+                'links' => [
+                    'self',
+                ],
+            ],
+        ]);
+
+        $entry->refresh()->load('richTextNotes');
+        $expectedNotes = mb_trim($entry->richTextNotes->render());
+
+        $response->assertJsonPath('data.attributes.notes', $expectedNotes);
+        $this->assertEquals('Notes for the day.', $entry->richTextNotes->toPlainText());
+    }
+}

--- a/tests/Feature/Controllers/Api/Journals/Notes/NotesControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Notes/NotesControllerTest.php
@@ -61,6 +61,6 @@ final class NotesControllerTest extends TestCase
         $expectedNotes = mb_trim($entry->richTextNotes->render());
 
         $response->assertJsonPath('data.attributes.notes', $expectedNotes);
-        $this->assertEquals('Notes for the day.', $entry->richTextNotes->toPlainText());
+        $this->assertEquals('Notes for the day.', mb_trim($entry->richTextNotes->toPlainText()));
     }
 }

--- a/tests/Feature/Controllers/Api/Journals/Notes/NotesResetControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Notes/NotesResetControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Notes;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class NotesResetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_notes_and_returns_the_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+        $entry->richTextNotes()->create([
+            'field' => 'notes',
+            'body' => '<p>Existing notes.</p>',
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/notes/reset");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.attributes.notes', null);
+
+        $entry->refresh()->load('richTextNotes');
+        $this->assertEquals('', $entry->richTextNotes->toPlainText());
+    }
+}


### PR DESCRIPTION
### Motivation
- Bring API parity with web UI by exposing journal entry `notes` (rich text) in API responses.
- Allow clients to create/update and reset notes via dedicated API endpoints for journal entries.
- Ensure API documentation and examples reflect the new `notes` attribute.
- Add automated tests to cover the new behavior and endpoints.

### Description
- Added API controllers `App\Http\Controllers\Api\Journals\Notes\NotesController` and `NotesResetController` to handle updating and resetting notes and return a `JournalEntryResource`.
- Registered new routes in `routes/api.php`: `PUT /api/journals/{id}/{year}/{month}/{day}/notes` and `PUT /api/journals/{id}/{year}/{month}/{day}/notes/reset` with the existing `journal.entry.api` middleware.
- Eager-loaded `richTextNotes` in `App\Http\Middleware\CheckJournalEntryAPI` and updated `App\Http\Resources\JournalEntryResource` to include a `notes` attribute that renders the rich text (or `null` when empty).
- Updated marketing docs partials (`resources/views/marketing/docs/api/partials/*`) to document and show an example `notes` field, and added/updated tests: modified `JournalEntryControllerTest` and added `NotesControllerTest` + `NotesResetControllerTest`.

### Testing
- Created PHPUnit tests: `tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php` (updated), `tests/Feature/Controllers/Api/Journals/Notes/NotesControllerTest.php` (new), and `tests/Feature/Controllers/Api/Journals/Notes/NotesResetControllerTest.php` (new).
- Attempted to run `vendor/bin/pint --dirty` but it could not be executed because `vendor/bin/pint` is not available in the environment (missing `vendor/`).
- Attempted to run `php artisan test` for the affected tests but they failed to start due to missing `vendor/autoload.php` in this environment, so tests could not be executed here.
- All tests have been added/updated and should pass when dependencies are installed and the test suite is run locally or in CI (run with `php artisan test --filter=JournalEntryControllerTest` and the two new notes tests to verify quickly).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696062d6605c83208710a6470614604e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New feature: expose journal entry notes in API responses
  - Notes rendered as HTML in attributes.notes (or null when empty)
  - Clients can create, update, and reset notes via API

- New API endpoints
  - PUT /api/journals/{id}/{year}/{month}/{day}/notes — update notes
  - PUT /api/journals/{id}/{year}/{month}/{day}/notes/reset — clear notes

- New controllers
  - NotesController — validates input (notes:string|max:100000) and runs LogNotes action
  - NotesResetController — runs ResetNotes action

- Resource & middleware updates
  - JournalEntryResource includes rendered notes attribute (normalized to null when empty)
  - CheckJournalEntryAPI now eager-loads richTextNotes

- Tests
  - Added NotesControllerTest and NotesResetControllerTest
  - Updated JournalEntryControllerTest to assert notes in responses
  - PHPUnit tests added but not runnable in this environment without vendor dependencies

- Docs
  - Updated marketing API documentation partials/examples to include notes

- Misc
  - LogNotes action refreshes entry before touch()
  - phpstan.neon updated to ignore undefined-method warnings for rich-text render/toPlainText
<!-- end of auto-generated comment: release notes by coderabbit.ai -->