### PR TITLE
refactor: extract log helpers in logging actions

### DIFF
--- a/app/Actions/LogActivityIntensity.php
+++ b/app/Actions/LogActivityIntensity.php
@@ -23,14 +23,7 @@ final readonly class LogActivityIntensity
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $modulePhysicalActivity->activity_intensity = $this->activityIntensity;
-        $modulePhysicalActivity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogActivityIntensity
                 'activity_intensity' => 'Invalid activity intensity.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $modulePhysicalActivity->activity_intensity = $this->activityIntensity;
+        $modulePhysicalActivity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogActivityType.php
+++ b/app/Actions/LogActivityType.php
@@ -23,14 +23,7 @@ final readonly class LogActivityType
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $modulePhysicalActivity->activity_type = $this->activityType;
-        $modulePhysicalActivity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogActivityType
                 'activity_type' => 'Invalid activity type.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $modulePhysicalActivity->activity_type = $this->activityType;
+        $modulePhysicalActivity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogBook.php
+++ b/app/Actions/LogBook.php
@@ -29,15 +29,7 @@ final readonly class LogBook
     public function execute(): void
     {
         $this->validate();
-
-        DB::table('book_journal_entry')->insert([
-            'book_id' => $this->book->id,
-            'journal_entry_id' => $this->entry->id,
-            'status' => $this->status->value,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +44,17 @@ final readonly class LogBook
         if ($this->book->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Book not found');
         }
+    }
+
+    private function log(): void
+    {
+        DB::table('book_journal_entry')->insert([
+            'book_id' => $this->book->id,
+            'journal_entry_id' => $this->entry->id,
+            'status' => $this->status->value,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogEnergy.php
+++ b/app/Actions/LogEnergy.php
@@ -23,14 +23,7 @@ final readonly class LogEnergy
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $moduleEnergy = $this->entry->moduleEnergy()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleEnergy->energy = $this->energy;
-        $moduleEnergy->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogEnergy
                 'energy' => 'Invalid energy value.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $moduleEnergy = $this->entry->moduleEnergy()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleEnergy->energy = $this->energy;
+        $moduleEnergy->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogHadKidsToday.php
+++ b/app/Actions/LogHadKidsToday.php
@@ -26,14 +26,7 @@ final readonly class LogHadKidsToday
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $moduleKids = $this->entry->moduleKids()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleKids->had_kids_today = $this->hadKidsToday;
-        $moduleKids->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogHadKidsToday
         if ($this->hadKidsToday !== 'yes' && $this->hadKidsToday !== 'no') {
             throw new InvalidArgumentException('hadKidsToday must be either "yes" or "no"');
         }
+    }
+
+    private function log(): void
+    {
+        $moduleKids = $this->entry->moduleKids()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleKids->had_kids_today = $this->hadKidsToday;
+        $moduleKids->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogHadSexualActivity.php
+++ b/app/Actions/LogHadSexualActivity.php
@@ -26,12 +26,7 @@ final readonly class LogHadSexualActivity
     public function execute(): JournalEntry
     {
         $this->validate();
-        $moduleSexualActivity = $this->entry->moduleSexualActivity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-        $moduleSexualActivity->had_sexual_activity = $this->hadSexualActivity;
-        $moduleSexualActivity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -50,6 +45,16 @@ final readonly class LogHadSexualActivity
         if ($this->hadSexualActivity !== 'yes' && $this->hadSexualActivity !== 'no') {
             throw new InvalidArgumentException('hadSexualActivity must be either "yes" or "no"');
         }
+    }
+
+    private function log(): void
+    {
+        $moduleSexualActivity = $this->entry->moduleSexualActivity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleSexualActivity->had_sexual_activity = $this->hadSexualActivity;
+        $moduleSexualActivity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogHasDonePhysicalActivity.php
+++ b/app/Actions/LogHasDonePhysicalActivity.php
@@ -23,14 +23,7 @@ final readonly class LogHasDonePhysicalActivity
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $modulePhysicalActivity->has_done_physical_activity = $this->hasDonePhysicalActivity;
-        $modulePhysicalActivity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogHasDonePhysicalActivity
                 'has_done_physical_activity' => 'Invalid physical activity status.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $modulePhysicalActivity = $this->entry->modulePhysicalActivity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $modulePhysicalActivity->has_done_physical_activity = $this->hasDonePhysicalActivity;
+        $modulePhysicalActivity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogHealth.php
+++ b/app/Actions/LogHealth.php
@@ -23,14 +23,7 @@ final readonly class LogHealth
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $moduleHealth = $this->entry->moduleHealth()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleHealth->health = $this->health;
-        $moduleHealth->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogHealth
                 'health' => 'Invalid health value.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $moduleHealth = $this->entry->moduleHealth()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleHealth->health = $this->health;
+        $moduleHealth->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogMood.php
+++ b/app/Actions/LogMood.php
@@ -23,14 +23,7 @@ final readonly class LogMood
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $moduleMood = $this->entry->moduleMood()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleMood->mood = $this->mood;
-        $moduleMood->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogMood
                 'mood' => 'Invalid mood value.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $moduleMood = $this->entry->moduleMood()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleMood->mood = $this->mood;
+        $moduleMood->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogPrimaryObligation.php
+++ b/app/Actions/LogPrimaryObligation.php
@@ -23,14 +23,7 @@ final readonly class LogPrimaryObligation
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $modulePrimaryObligation = $this->entry->modulePrimaryObligation()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $modulePrimaryObligation->primary_obligation = $this->primaryObligation;
-        $modulePrimaryObligation->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogPrimaryObligation
                 'primary_obligation' => 'Invalid primary obligation value.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $modulePrimaryObligation = $this->entry->modulePrimaryObligation()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $modulePrimaryObligation->primary_obligation = $this->primaryObligation;
+        $modulePrimaryObligation->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogSexualActivityType.php
+++ b/app/Actions/LogSexualActivityType.php
@@ -28,12 +28,7 @@ final readonly class LogSexualActivityType
     public function execute(): JournalEntry
     {
         $this->validate();
-        $moduleSexualActivity = $this->entry->moduleSexualActivity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-        $moduleSexualActivity->sexual_activity_type = $this->sexualActivityType;
-        $moduleSexualActivity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +47,16 @@ final readonly class LogSexualActivityType
         if (! in_array($this->sexualActivityType, self::VALID_TYPES, true)) {
             throw new InvalidArgumentException('sexualActivityType must be one of: ' . implode(', ', self::VALID_TYPES));
         }
+    }
+
+    private function log(): void
+    {
+        $moduleSexualActivity = $this->entry->moduleSexualActivity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleSexualActivity->sexual_activity_type = $this->sexualActivityType;
+        $moduleSexualActivity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogSocialDensity.php
+++ b/app/Actions/LogSocialDensity.php
@@ -23,14 +23,7 @@ final readonly class LogSocialDensity
     public function execute(): JournalEntry
     {
         $this->validate();
-
-        $moduleSocialDensity = $this->entry->moduleSocialDensity()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleSocialDensity->social_density = $this->socialDensity;
-        $moduleSocialDensity->save();
-
+        $this->log();
         $this->logUserAction();
         $this->updateUserLastActivityDate();
         $this->refreshContentPresenceStatus();
@@ -52,6 +45,16 @@ final readonly class LogSocialDensity
                 'social_density' => 'Invalid social density value.',
             ]);
         }
+    }
+
+    private function log(): void
+    {
+        $moduleSocialDensity = $this->entry->moduleSocialDensity()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleSocialDensity->social_density = $this->socialDensity;
+        $moduleSocialDensity->save();
     }
 
     private function logUserAction(): void

--- a/app/Actions/LogTravelMode.php
+++ b/app/Actions/LogTravelMode.php
@@ -56,6 +56,16 @@ final readonly class LogTravelMode
         }
     }
 
+    private function log(): void
+    {
+        $moduleTravel = $this->entry->moduleTravel()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleTravel->travel_mode = $this->travelModes;
+        $moduleTravel->save();
+    }
+
     private function logUserAction(): void
     {
         LogUserAction::dispatch(
@@ -69,16 +79,6 @@ final readonly class LogTravelMode
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
-    }
-
-    private function log(): void
-    {
-        $moduleTravel = $this->entry->moduleTravel()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleTravel->travel_mode = $this->travelModes;
-        $moduleTravel->save();
     }
 
     private function refreshContentPresenceStatus(): void

--- a/app/Actions/LogTravelledToday.php
+++ b/app/Actions/LogTravelledToday.php
@@ -48,6 +48,16 @@ final readonly class LogTravelledToday
         }
     }
 
+    private function log(): void
+    {
+        $moduleTravel = $this->entry->moduleTravel()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        $moduleTravel->has_traveled_today = $this->hasTraveled;
+        $moduleTravel->save();
+    }
+
     private function logUserAction(): void
     {
         LogUserAction::dispatch(
@@ -61,16 +71,6 @@ final readonly class LogTravelledToday
     private function updateUserLastActivityDate(): void
     {
         UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
-    }
-
-    private function log(): void
-    {
-        $moduleTravel = $this->entry->moduleTravel()->firstOrCreate(
-            ['journal_entry_id' => $this->entry->id],
-        );
-
-        $moduleTravel->has_traveled_today = $this->hasTraveled;
-        $moduleTravel->save();
     }
 
     private function refreshContentPresenceStatus(): void

--- a/tests/Unit/Actions/LogActivityIntensityTest.php
+++ b/tests/Unit/Actions/LogActivityIntensityTest.php
@@ -42,6 +42,7 @@ final class LogActivityIntensityTest extends TestCase
         ))->execute();
 
         $this->assertEquals('light', $result->modulePhysicalActivity->activity_intensity);
+        $this->assertSame($entry->id, $result->modulePhysicalActivity->journal_entry_id);
 
         Queue::assertPushedOn(
             queue: 'low',


### PR DESCRIPTION
### Motivation

- Move inline module update logic out of `execute()` into a small `log()` helper for clarity and reuse.
- Keep `execute()` focused on orchestration by placing the `log()` call between `validate()` and `logUserAction()`.
- Improve readability and make future changes to module updates easier and less error-prone.

### Description

- Added private `log()` helpers and replaced inline module update code with `$this->log()` in multiple actions including `LogActivityIntensity`, `LogActivityType`, `LogEnergy`, `LogMood`, `LogHealth`, `LogPrimaryObligation`, `LogSocialDensity`, `LogHasDonePhysicalActivity`, `LogHadKidsToday`, `LogHadSexualActivity`, `LogSexualActivityType`, `LogBook`, `LogTravelMode`, and `LogTravelledToday`.
- Ensured the `log()` call is invoked immediately after `validate()` and before `logUserAction()` in each `execute()` implementation to preserve behavior ordering.
- Reordered travel-related helpers so `log()` sits between `validate()` and `logUserAction()` for `LogTravelMode` and `LogTravelledToday` to match the pattern.
- Added an assertion in `tests/Unit/Actions/LogActivityIntensityTest.php` to verify the `modulePhysicalActivity->journal_entry_id` is linked to the `JournalEntry`.

### Testing

- Ran `php artisan test tests/Unit/Actions/LogActivityIntensityTest.php` but it failed due to missing vendor autoload (`vendor/autoload.php`), so tests could not be executed here.
- Ran the repository test runner `composer journalos:unit` which also failed for the same missing `vendor/autoload.php` reason.
- Attempted to run `vendor/bin/pint --dirty` for formatting but the binary was not found in the environment, so formatting could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962bfa6ecf88320b4f40fc4ac0073d1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Refactored logging actions**: Extracted inline module update logic into private `log()` helper methods across 14 action classes to improve code clarity and reusability
- **Affected actions**: LogActivityIntensity, LogActivityType, LogEnergy, LogMood, LogHealth, LogPrimaryObligation, LogSocialDensity, LogHasDonePhysicalActivity, LogHadKidsToday, LogHadSexualActivity, LogSexualActivityType, LogBook, LogTravelMode, and LogTravelledToday
- **Improved separation of concerns**: The `execute()` method now focuses on orchestration by delegating data persistence to dedicated `log()` methods while maintaining consistent behavior ordering (validate → log → logUserAction → update dates → refresh status)
- **Added test assertion**: Verified that `modulePhysicalActivity->journal_entry_id` is properly linked to the JournalEntry in LogActivityIntensityTest
- **No breaking changes**: All modifications are internal refactorings with no impact to public APIs or functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->