### PR TITLE
refactor: group journal entry api routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -59,161 +59,89 @@ Route::name('api.')->group(function (): void {
             Route::get('journals/{id}', [Journals\JournalController::class, 'show'])->name('journal.show');
 
             Route::middleware(['journal.entry.api'])->group(function (): void {
-                Route::get('journals/{id}/{year}/{month}/{day}', [JournalEntryController::class, 'show'])
+                Route::prefix('journals/{id}/{year}/{month}/{day}')
                     ->whereNumber('year')
                     ->whereNumber('month')
                     ->whereNumber('day')
-                    ->name('journal.entry.show');
+                    ->group(function (): void {
+                        Route::get('', [JournalEntryController::class, 'show'])
+                            ->name('journal.entry.show');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/sleep/bedtime', [SleepBedTimeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.sleep.bedtime.update');
+                        Route::put('sleep/bedtime', [SleepBedTimeController::class, 'update'])
+                            ->name('journal.entry.sleep.bedtime.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/sleep/wake_up_time', [SleepWakeUpTimeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.sleep.wake_up_time.update');
+                        Route::put('sleep/wake_up_time', [SleepWakeUpTimeController::class, 'update'])
+                            ->name('journal.entry.sleep.wake_up_time.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/work', [WorkController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.work.update');
+                        Route::put('work', [WorkController::class, 'update'])
+                            ->name('journal.entry.work.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/work/mode', [WorkModeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.work.mode.update');
+                        Route::put('work/mode', [WorkModeController::class, 'update'])
+                            ->name('journal.entry.work.mode.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/work/load', [WorkLoadController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.work.load.update');
+                        Route::put('work/load', [WorkLoadController::class, 'update'])
+                            ->name('journal.entry.work.load.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/work/procrastinated', [WorkProcrastinatedController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.work.procrastinated.update');
+                        Route::put('work/procrastinated', [WorkProcrastinatedController::class, 'update'])
+                            ->name('journal.entry.work.procrastinated.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/travel', [TravelController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.travel.update');
+                        Route::put('travel', [TravelController::class, 'update'])
+                            ->name('journal.entry.travel.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/travel/mode', [TravelModeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.travel.mode.update');
+                        Route::put('travel/mode', [TravelModeController::class, 'update'])
+                            ->name('journal.entry.travel.mode.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/shopping', [ShoppingController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.shopping.update');
+                        Route::put('shopping', [ShoppingController::class, 'update'])
+                            ->name('journal.entry.shopping.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/shopping/type', [ShoppingTypeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.shopping.type.update');
+                        Route::put('shopping/type', [ShoppingTypeController::class, 'update'])
+                            ->name('journal.entry.shopping.type.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/shopping/intent', [ShoppingIntentController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.shopping.intent.update');
+                        Route::put('shopping/intent', [ShoppingIntentController::class, 'update'])
+                            ->name('journal.entry.shopping.intent.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/shopping/context', [ShoppingContextController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.shopping.context.update');
+                        Route::put('shopping/context', [ShoppingContextController::class, 'update'])
+                            ->name('journal.entry.shopping.context.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/shopping/for', [ShoppingForController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.shopping.for.update');
+                        Route::put('shopping/for', [ShoppingForController::class, 'update'])
+                            ->name('journal.entry.shopping.for.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/kids', [KidsModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.kids.update');
+                        Route::put('kids', [KidsModuleController::class, 'update'])
+                            ->name('journal.entry.kids.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/day-type', [DayTypeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.day-type.update');
+                        Route::put('day-type', [DayTypeController::class, 'update'])
+                            ->name('journal.entry.day-type.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/primary-obligation', [PrimaryObligationModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.primary-obligation.update');
+                        Route::put('primary-obligation', [PrimaryObligationModuleController::class, 'update'])
+                            ->name('journal.entry.primary-obligation.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/physical-activity', [PhysicalActivityController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.physical-activity.update');
+                        Route::put('physical-activity', [PhysicalActivityController::class, 'update'])
+                            ->name('journal.entry.physical-activity.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/sexual-activity', [SexualActivityController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.sexual-activity.update');
+                        Route::put('sexual-activity', [SexualActivityController::class, 'update'])
+                            ->name('journal.entry.sexual-activity.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/sexual-activity/type', [SexualActivityTypeController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.sexual-activity.type.update');
+                        Route::put('sexual-activity/type', [SexualActivityTypeController::class, 'update'])
+                            ->name('journal.entry.sexual-activity.type.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/health', [HealthModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.health.update');
+                        Route::put('health', [HealthModuleController::class, 'update'])
+                            ->name('journal.entry.health.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/mood', [MoodModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.mood.update');
+                        Route::put('mood', [MoodModuleController::class, 'update'])
+                            ->name('journal.entry.mood.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/energy', [EnergyModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.energy.update');
+                        Route::put('energy', [EnergyModuleController::class, 'update'])
+                            ->name('journal.entry.energy.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/social-density', [SocialDensityModuleController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.social-density.update');
+                        Route::put('social-density', [SocialDensityModuleController::class, 'update'])
+                            ->name('journal.entry.social-density.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/notes', [NotesController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.notes.update');
+                        Route::put('notes', [NotesController::class, 'update'])
+                            ->name('journal.entry.notes.update');
 
-                Route::put('journals/{id}/{year}/{month}/{day}/notes/reset', [NotesResetController::class, 'update'])
-                    ->whereNumber('year')
-                    ->whereNumber('month')
-                    ->whereNumber('day')
-                    ->name('journal.entry.notes.reset');
+                        Route::put('notes/reset', [NotesResetController::class, 'update'])
+                            ->name('journal.entry.notes.reset');
+                    });
             });
 
             // settings

--- a/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php
@@ -127,6 +127,21 @@ final class JournalEntryControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_not_found_for_non_numeric_date_segments(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('GET', '/api/journals/' . $journal->id . '/year/4/12');
+
+        $response->assertStatus(404);
+    }
+
+    #[Test]
     public function it_restricts_access_to_journal_entries_the_user_does_not_own(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
### Motivation

- Remove repeated `->whereNumber('year')`, `->whereNumber('month')`, and `->whereNumber('day')` calls and avoid repeating the long `journals/{id}/{year}/{month}/{day}` prefix across many journal-entry routes.
- Keep all routes, HTTP verbs, middleware stacks, and route names unchanged while reducing duplication.

### Description

- Consolidated the date segment constraints by introducing a `Route::prefix('journals/{id}/{year}/{month}/{day}')->whereNumber('year')->whereNumber('month')->whereNumber('day')->group(...)` under the existing `journal.entry.api` middleware.
- Converted each previously fully-qualified route path to a child route suffix (for example `sleep/bedtime`) inside the new group so the final URLs and route names remain identical.
- Updated `routes/api.php` to use the shared prefix and moved all `whereNumber` constraints to the group-level, preserving `Route::name('api.')`, auth/throttle middleware and controller actions.
- Added a test to ensure non-numeric date segments are rejected: `tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest::it_returns_not_found_for_non_numeric_date_segments`.

### Testing

- Added the new test `tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest::it_returns_not_found_for_non_numeric_date_segments` but it was not executed in this environment.
- Attempted to run `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` was not available in the workspace.
- Attempted to run `php artisan test tests/Feature/Controllers/Api/Journals/JournalEntryControllerTest.php`, which failed due to a missing `vendor/autoload.php` in the environment.
- Attempted `composer journalos:unit`, which also failed for the same missing vendor dependencies reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e17437fc8320a027be9a08f2ef03)