### PR TITLE
ci: enable pgsql parallel tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           sudo systemctl start postgresql.service
           sudo -u postgres psql --command="CREATE USER journalos PASSWORD 'secret'" --command="\du"
+          sudo -u postgres psql --command="ALTER USER journalos CREATEDB"
           sudo -u postgres createdb --owner=journalos journalos
           PGPASSWORD=secret psql --username=journalos --host=localhost --list journalos
 
@@ -158,6 +159,6 @@ jobs:
 
       - name: Run tests (pgsql)
         if: matrix.connection == 'pgsql'
-        run: php artisan test
+        run: php artisan test --parallel --recreate-databases
         env:
           DB_CONNECTION: ${{ matrix.connection }}


### PR DESCRIPTION
### Motivation

- Grant the CI Postgres test user permission to create databases so parallel test processes can provision their own DBs.
- Run Postgres tests in parallel with database recreation to speed up CI and avoid database conflicts between workers.
- Apply the change to the GitHub Actions workflow file at `.github/workflows/tests.yml`.

### Description

- Added `sudo -u postgres psql --command="ALTER USER journalos CREATEDB"` to the `Create pgsql database` step.
- Changed the Postgres test step to run `php artisan test --parallel --recreate-databases` under the `Run tests (pgsql)` job.
- Modified `.github/workflows/tests.yml` to include these updates.

### Testing

- Ran `php artisan test --filter=HealthControllerTest` locally but it failed due to missing `vendor/autoload.php` because `composer install` was blocked by network-restricted dependency fetches (failure).
- Attempted `vendor/bin/pint --dirty` locally but it failed because dependencies were not installed (failure).
- No CI execution was performed in this environment, so CI validation is expected to run on GitHub Actions (not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e60b5ca883209fbee57d7fede2fe)