### PR TITLE
feat: add Hygiene module

### DIFF
--- a/app/Actions/LogHygiene.php
+++ b/app/Actions/LogHygiene.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException;
+
+final readonly class LogHygiene
+{
+    public function __construct(
+        private User $user,
+        private JournalEntry $entry,
+        private ?string $showered,
+        private ?string $brushedTeeth,
+        private ?string $skincare,
+    ) {}
+
+    public function execute(): JournalEntry
+    {
+        $this->validate();
+        $this->log();
+        $this->logUserAction();
+        $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
+
+        $this->entry->load('moduleHygiene');
+
+        return $this->entry;
+    }
+
+    private function validate(): void
+    {
+        if ($this->entry->journal->user_id !== $this->user->id) {
+            throw new ModelNotFoundException('Journal entry not found');
+        }
+
+        if ($this->showered === null && $this->brushedTeeth === null && $this->skincare === null) {
+            throw ValidationException::withMessages([
+                'hygiene' => 'At least one hygiene value is required.',
+            ]);
+        }
+
+        if ($this->showered !== null && ! in_array($this->showered, ['yes', 'no'], true)) {
+            throw ValidationException::withMessages([
+                'showered' => 'Invalid showered value.',
+            ]);
+        }
+
+        if ($this->brushedTeeth !== null && ! in_array($this->brushedTeeth, ['no', 'am', 'pm'], true)) {
+            throw ValidationException::withMessages([
+                'brushed_teeth' => 'Invalid brushed teeth value.',
+            ]);
+        }
+
+        if ($this->skincare !== null && ! in_array($this->skincare, ['yes', 'no'], true)) {
+            throw ValidationException::withMessages([
+                'skincare' => 'Invalid skincare value.',
+            ]);
+        }
+    }
+
+    private function log(): void
+    {
+        $moduleHygiene = $this->entry->moduleHygiene()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        if ($this->showered !== null) {
+            $moduleHygiene->showered = $this->showered;
+        }
+
+        if ($this->brushedTeeth !== null) {
+            $moduleHygiene->brushed_teeth = $this->brushedTeeth;
+        }
+
+        if ($this->skincare !== null) {
+            $moduleHygiene->skincare = $this->skincare;
+        }
+
+        $moduleHygiene->save();
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            journal: $this->entry->journal,
+            action: 'hygiene_logged',
+            description: 'Logged hygiene for ' . $this->entry->getDate(),
+        )->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
+    }
+}

--- a/app/Actions/ResetHygieneData.php
+++ b/app/Actions/ResetHygieneData.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final readonly class ResetHygieneData
+{
+    public function __construct(
+        private User $user,
+        private JournalEntry $entry,
+    ) {}
+
+    public function execute(): JournalEntry
+    {
+        $this->validate();
+
+        $moduleHygiene = $this->entry->moduleHygiene;
+        if ($moduleHygiene !== null) {
+            $moduleHygiene->delete();
+        }
+
+        $this->logUserAction();
+        $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
+
+        $this->entry->load('moduleHygiene');
+
+        return $this->entry;
+    }
+
+    private function validate(): void
+    {
+        if ($this->entry->journal->user_id !== $this->user->id) {
+            throw new ModelNotFoundException('Journal entry not found');
+        }
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            journal: $this->entry->journal,
+            action: 'hygiene_reset',
+            description: 'Reset hygiene data for ' . $this->entry->getDate(),
+        )->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
+    }
+}

--- a/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
@@ -27,9 +27,9 @@ final class HygieneController extends Controller
         $entry = new LogHygiene(
             user: Auth::user(),
             entry: $entry,
-            showered: array_key_exists('showered', $validated) ? TextSanitizer::plainText($validated['showered']) : null,
-            brushedTeeth: array_key_exists('brushed_teeth', $validated) ? TextSanitizer::plainText($validated['brushed_teeth']) : null,
-            skincare: array_key_exists('skincare', $validated) ? TextSanitizer::plainText($validated['skincare']) : null,
+            showered: array_key_exists('showered', $validated) ? TextSanitizer::nullablePlainText($validated['showered']) : null,
+            brushedTeeth: array_key_exists('brushed_teeth', $validated) ? TextSanitizer::nullablePlainText($validated['brushed_teeth']) : null,
+            skincare: array_key_exists('skincare', $validated) ? TextSanitizer::nullablePlainText($validated['skincare']) : null,
         )->execute();
 
         return response()->json([

--- a/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Modules\Hygiene;
+
+use App\Actions\LogHygiene;
+use App\Helpers\TextSanitizer;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class HygieneController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $validated = $request->validate([
+            'showered' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:brushed_teeth,skincare'],
+            'brushed_teeth' => ['nullable', 'string', 'max:255', 'in:no,am,pm', 'required_without_all:showered,skincare'],
+            'skincare' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:showered,brushed_teeth'],
+        ]);
+
+        $entry = new LogHygiene(
+            user: Auth::user(),
+            entry: $entry,
+            showered: array_key_exists('showered', $validated) ? TextSanitizer::plainText($validated['showered']) : null,
+            brushedTeeth: array_key_exists('brushed_teeth', $validated) ? TextSanitizer::plainText($validated['brushed_teeth']) : null,
+            skincare: array_key_exists('skincare', $validated) ? TextSanitizer::plainText($validated['skincare']) : null,
+        )->execute();
+
+        return response()->json([
+            'data' => new JournalEntryResource($entry),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\App\Journals\Modules\Hygiene;
+
+use App\Actions\LogHygiene;
+use App\Helpers\TextSanitizer;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+final class HygieneController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $validated = $request->validate([
+            'showered' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:brushed_teeth,skincare'],
+            'brushed_teeth' => ['nullable', 'string', 'max:255', 'in:no,am,pm', 'required_without_all:showered,skincare'],
+            'skincare' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:showered,brushed_teeth'],
+        ]);
+
+        new LogHygiene(
+            user: Auth::user(),
+            entry: $entry,
+            showered: array_key_exists('showered', $validated) ? TextSanitizer::plainText($validated['showered']) : null,
+            brushedTeeth: array_key_exists('brushed_teeth', $validated) ? TextSanitizer::plainText($validated['brushed_teeth']) : null,
+            skincare: array_key_exists('skincare', $validated) ? TextSanitizer::plainText($validated['skincare']) : null,
+        )->execute();
+
+        return to_route('journal.entry.show', [
+            'slug' => $entry->journal->slug,
+            'year' => $entry->year,
+            'month' => $entry->month,
+            'day' => $entry->day,
+        ])->with('status', __('Changes saved'));
+    }
+}

--- a/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneResetController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneResetController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\App\Journals\Modules\Hygiene;
+
+use App\Actions\ResetHygieneData;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+final class HygieneResetController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        new ResetHygieneData(
+            user: Auth::user(),
+            entry: $entry,
+        )->execute();
+
+        return to_route('journal.entry.show', [
+            'slug' => $entry->journal->slug,
+            'year' => $entry->year,
+            'month' => $entry->month,
+            'day' => $entry->day,
+        ])->with('status', __('Changes saved'));
+    }
+}

--- a/app/Http/Controllers/Marketing/Docs/Api/Modules/HygieneController.php
+++ b/app/Http/Controllers/Marketing/Docs/Api/Modules/HygieneController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\View\View;
+
+final class HygieneController extends Controller
+{
+    public function index(): View
+    {
+        RecordMarketingPageVisit::dispatch(viewName: 'marketing.docs.api.modules.hygiene')->onQueue('low');
+
+        return view('marketing.docs.api.modules.hygiene');
+    }
+}

--- a/app/Http/Resources/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntryResource.php
@@ -73,6 +73,11 @@ final class JournalEntryResource extends JsonResource
                     'health' => [
                         'health' => $this->moduleHealth?->health,
                     ],
+                    'hygiene' => [
+                        'showered' => $this->moduleHygiene?->showered,
+                        'brushed_teeth' => $this->moduleHygiene?->brushed_teeth,
+                        'skincare' => $this->moduleHygiene?->skincare,
+                    ],
                     'mood' => [
                         'mood' => $this->moduleMood?->mood,
                     ],

--- a/app/Jobs/CheckPresenceOfContentInJournalEntry.php
+++ b/app/Jobs/CheckPresenceOfContentInJournalEntry.php
@@ -34,6 +34,7 @@ final class CheckPresenceOfContentInJournalEntry implements ShouldQueue
             'moduleWork',
             'moduleSexualActivity',
             'moduleHealth',
+            'moduleHygiene',
             'moduleDayType',
             'moduleTravel',
             'moduleShopping',
@@ -101,6 +102,13 @@ final class CheckPresenceOfContentInJournalEntry implements ShouldQueue
 
         if (! $hasContent && $this->entry->moduleHealth !== null) {
             if ($this->entry->moduleHealth->health !== null) {
+                $hasContent = true;
+            }
+        }
+
+        if (! $hasContent && $this->entry->moduleHygiene !== null) {
+            $moduleHygiene = $this->entry->moduleHygiene;
+            if ($moduleHygiene->showered !== null || $moduleHygiene->brushed_teeth !== null || $moduleHygiene->skincare !== null) {
                 $hasContent = true;
             }
         }

--- a/app/Jobs/DeleteRelatedJournalData.php
+++ b/app/Jobs/DeleteRelatedJournalData.php
@@ -27,6 +27,7 @@ final class DeleteRelatedJournalData implements ShouldQueue
         'module_work' => 'journal_entry_id',
         'module_travel' => 'journal_entry_id',
         'module_health' => 'journal_entry_id',
+        'module_hygiene' => 'journal_entry_id',
         'module_mood' => 'journal_entry_id',
         'module_day_type' => 'journal_entry_id',
         'module_physical_activity' => 'journal_entry_id',

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool $show_primary_obligation_module
  * @property bool $show_physical_activity_module
  * @property bool $show_health_module
+ * @property bool $show_hygiene_module
  * @property bool $show_mood_module
  * @property bool $show_sexual_activity_module
  * @property bool $show_energy_module
@@ -65,6 +66,7 @@ final class Journal extends Model
         'show_primary_obligation_module',
         'show_physical_activity_module',
         'show_health_module',
+        'show_hygiene_module',
         'show_mood_module',
         'show_sexual_activity_module',
         'show_energy_module',
@@ -90,6 +92,7 @@ final class Journal extends Model
             'show_primary_obligation_module' => 'boolean',
             'show_physical_activity_module' => 'boolean',
             'show_health_module' => 'boolean',
+            'show_hygiene_module' => 'boolean',
             'show_mood_module' => 'boolean',
             'show_sexual_activity_module' => 'boolean',
             'show_energy_module' => 'boolean',

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -185,6 +185,16 @@ final class JournalEntry extends Model
     }
 
     /**
+     * Get the hygiene module data for this entry.
+     *
+     * @return HasOne<ModuleHygiene, $this>
+     */
+    public function moduleHygiene(): HasOne
+    {
+        return $this->hasOne(ModuleHygiene::class, 'journal_entry_id');
+    }
+
+    /**
      * Get the day type module data for this entry.
      *
      * @return HasOne<ModuleDayType, $this>

--- a/app/Models/ModuleHygiene.php
+++ b/app/Models/ModuleHygiene.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class ModuleHygiene
+ *
+ * Represents hygiene tracking data for a journal entry.
+ *
+ * @property int $id
+ * @property int $journal_entry_id
+ * @property string $category # Format: string
+ * @property string|null $showered # Format: 'yes', 'no'
+ * @property string|null $brushed_teeth # Format: 'no', 'am', 'pm'
+ * @property string|null $skincare # Format: 'yes', 'no'
+ * @property Carbon $created_at
+ * @property Carbon|null $updated_at
+ */
+final class ModuleHygiene extends Model
+{
+    /** @use HasFactory<\Database\Factories\ModuleHygieneFactory> */
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'module_hygiene';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'journal_entry_id',
+        'category',
+        'showered',
+        'brushed_teeth',
+        'skincare',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'showered' => 'encrypted',
+            'brushed_teeth' => 'encrypted',
+            'skincare' => 'encrypted',
+        ];
+    }
+
+    /**
+     * Get the journal entry that owns the hygiene module.
+     *
+     * @return BelongsTo<JournalEntry, $this>
+     */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(JournalEntry::class, 'journal_entry_id');
+    }
+}

--- a/app/View/Presenters/HygieneModulePresenter.php
+++ b/app/View/Presenters/HygieneModulePresenter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Presenters;
+
+use App\Models\JournalEntry;
+
+final readonly class HygieneModulePresenter
+{
+    public function __construct(
+        private JournalEntry $entry,
+    ) {}
+
+    public function build(): array
+    {
+        $module = $this->entry->moduleHygiene;
+        $displayReset = $module?->showered !== null
+            || $module?->brushed_teeth !== null
+            || $module?->skincare !== null;
+
+        return [
+            'hygiene_url' => route('journal.entry.hygiene.update', [
+                'slug' => $this->entry->journal->slug,
+                'year' => $this->entry->year,
+                'month' => $this->entry->month,
+                'day' => $this->entry->day,
+            ]),
+            'reset_url' => route('journal.entry.hygiene.reset', [
+                'slug' => $this->entry->journal->slug,
+                'year' => $this->entry->year,
+                'month' => $this->entry->month,
+                'day' => $this->entry->day,
+            ]),
+            'showered_options' => $this->yesNoOptions($module?->showered),
+            'brushed_teeth_options' => $this->brushedTeethOptions($module?->brushed_teeth),
+            'skincare_options' => $this->yesNoOptions($module?->skincare),
+            'display_reset' => $displayReset,
+        ];
+    }
+
+    private function yesNoOptions(?string $value): array
+    {
+        return collect(['yes', 'no'])->map(fn($option) => [
+            'value' => $option,
+            'label' => $option === 'yes' ? __('Yes') : __('No'),
+            'is_selected' => $value === $option,
+        ])->all();
+    }
+
+    private function brushedTeethOptions(?string $value): array
+    {
+        return collect(['no', 'am', 'pm'])->map(fn($option) => [
+            'value' => $option,
+            'label' => match ($option) {
+                'no' => __('No'),
+                'am' => __('AM'),
+                'pm' => __('PM'),
+                default => $option,
+            },
+            'is_selected' => $value === $option,
+        ])->all();
+    }
+}

--- a/app/View/Presenters/JournalEntryPresenter.php
+++ b/app/View/Presenters/JournalEntryPresenter.php
@@ -66,6 +66,12 @@ final readonly class JournalEntryPresenter
             $health = [];
         }
 
+        if ($this->entry->journal->show_hygiene_module) {
+            $hygiene = new HygieneModulePresenter($this->entry)->build();
+        } else {
+            $hygiene = [];
+        }
+
         if ($this->entry->journal->show_mood_module) {
             $mood = new MoodModulePresenter($this->entry)->build();
         } else {
@@ -102,6 +108,7 @@ final readonly class JournalEntryPresenter
             'primary_obligation' => $primaryObligation,
             'physical_activity' => $physicalActivity,
             'health' => $health,
+            'hygiene' => $hygiene,
             'mood' => $mood,
             'sexual_activity' => $sexualActivity,
             'energy' => $energy,

--- a/database/factories/ModuleHygieneFactory.php
+++ b/database/factories/ModuleHygieneFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ModuleHygiene>
+ */
+final class ModuleHygieneFactory extends Factory
+{
+    protected $model = ModuleHygiene::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'journal_entry_id' => JournalEntry::factory(),
+            'showered' => $this->faker->randomElement(['yes', 'no']),
+            'brushed_teeth' => $this->faker->randomElement(['no', 'am', 'pm']),
+            'skincare' => $this->faker->randomElement(['yes', 'no']),
+        ];
+    }
+}

--- a/database/migrations/2026_01_12_000000_create_module_hygiene_table.php
+++ b/database/migrations/2026_01_12_000000_create_module_hygiene_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ModuleType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('module_hygiene', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
+            $table->text('showered')->nullable();
+            $table->text('brushed_teeth')->nullable();
+            $table->text('skincare')->nullable();
+            $table->timestamps();
+            $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('module_hygiene');
+    }
+};

--- a/database/migrations/2026_01_12_000001_add_show_hygiene_module_to_journals_table.php
+++ b/database/migrations/2026_01_12_000001_add_show_hygiene_module_to_journals_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('journals', function (Blueprint $table): void {
+            $table->boolean('show_hygiene_module')->default(true)->after('show_health_module');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('journals', function (Blueprint $table): void {
+            $table->dropColumn('show_hygiene_module');
+        });
+    }
+};

--- a/resources/views/app/journal/entry/partials/hygiene.blade.php
+++ b/resources/views/app/journal/entry/partials/hygiene.blade.php
@@ -1,0 +1,67 @@
+<x-module>
+  <x-slot:title>{{ __('Hygiene') }}</x-slot>
+  <x-slot:emoji>🧼</x-slot>
+  <x-slot:action>
+    <div id="hygiene-reset">
+      @if ($module['display_reset'])
+        <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['reset_url']" method="put">
+          <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
+            {{ __('Reset') }}
+          </button>
+        </x-form>
+      @endif
+    </div>
+  </x-slot>
+
+  <div id="hygiene-container">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-2">
+        <p>{{ __('Showered') }}</p>
+        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+          @foreach ($module['showered_options'] as $option)
+            <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
+              <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
+                <input type="hidden" name="showered" value="{{ $option['value'] }}" />
+                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
+                  {{ $option['label'] }}
+                </button>
+              </x-form>
+            </div>
+          @endforeach
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <p>{{ __('Brushed teeth') }}</p>
+        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+          @foreach ($module['brushed_teeth_options'] as $option)
+            <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
+              <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
+                <input type="hidden" name="brushed_teeth" value="{{ $option['value'] }}" />
+                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
+                  {{ $option['label'] }}
+                </button>
+              </x-form>
+            </div>
+          @endforeach
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <p>{{ __('Skincare') }}</p>
+        <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+          @foreach ($module['skincare_options'] as $option)
+            <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
+              <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
+                <input type="hidden" name="skincare" value="{{ $option['value'] }}" />
+                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
+                  {{ $option['label'] }}
+                </button>
+              </x-form>
+            </div>
+          @endforeach
+        </div>
+      </div>
+    </div>
+  </div>
+</x-module>

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -102,6 +102,10 @@
           @include('app.journal.entry.partials.health', ['module' => $modules['health']])
         @endif
 
+        @if ($journal->show_hygiene_module)
+          @include('app.journal.entry.partials.hygiene', ['module' => $modules['hygiene']])
+        @endif
+
         @if ($journal->show_mood_module)
           @include('app.journal.entry.partials.mood', ['module' => $modules['mood']])
         @endif

--- a/resources/views/app/journal/settings/partials/modules.blade.php
+++ b/resources/views/app/journal/settings/partials/modules.blade.php
@@ -9,12 +9,12 @@
     <div class="inline-flex h-9 items-center justify-start gap-1 rounded-lg bg-gray-100 p-1 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
       <button type="button" @click="activeTab = 'all'" :class="activeTab === 'all' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>{{ __('All') }}</span>
-        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">13</span>
+        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">14</span>
       </button>
       <button type="button" @click="activeTab = 'body'" :class="activeTab === 'body' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>💪</span>
         <span>{{ __('Body & Health') }}</span>
-        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">3</span>
+        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">4</span>
       </button>
       <button type="button" @click="activeTab = 'mind'" :class="activeTab === 'mind' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>🧠</span>
@@ -74,6 +74,17 @@
           <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Health module') }}</p>
           <div class="w-full justify-self-start">
             <x-toggle name="enabled" :checked="$journal->show_health_module">{{ $journal->show_health_module ? __('Enabled') : __('Disabled') }}</x-toggle>
+          </div>
+        </div>
+      </x-form>
+
+      <!-- hygiene module -->
+      <x-form method="put" action="{{ route('journal.settings.modules.update', ['slug' => $journal->slug]) }}" x-target="modules-container notifications" x-target.back="modules-container" id="hygiene-module-form">
+        <input type="hidden" name="module" value="hygiene" />
+        <div class="grid grid-cols-3 items-center border-b border-gray-200 p-3 hover:bg-blue-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Hygiene module') }}</p>
+          <div class="w-full justify-self-start">
+            <x-toggle name="enabled" :checked="$journal->show_hygiene_module">{{ $journal->show_hygiene_module ? __('Enabled') : __('Disabled') }}</x-toggle>
           </div>
         </div>
       </x-form>
@@ -214,6 +225,17 @@
           <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Health module') }}</p>
           <div class="w-full justify-self-start">
             <x-toggle name="enabled" :checked="$journal->show_health_module">{{ $journal->show_health_module ? __('Enabled') : __('Disabled') }}</x-toggle>
+          </div>
+        </div>
+      </x-form>
+
+      <!-- hygiene module -->
+      <x-form method="put" action="{{ route('journal.settings.modules.update', ['slug' => $journal->slug]) }}" x-target="modules-container notifications" x-target.back="modules-container">
+        <input type="hidden" name="module" value="hygiene" />
+        <div class="grid grid-cols-3 items-center border-b border-gray-200 p-3 hover:bg-blue-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Hygiene module') }}</p>
+          <div class="w-full justify-self-start">
+            <x-toggle name="enabled" :checked="$journal->show_hygiene_module">{{ $journal->show_hygiene_module ? __('Enabled') : __('Disabled') }}</x-toggle>
           </div>
         </div>
       </x-form>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -122,6 +122,9 @@
                 <a href="{{ route('marketing.docs.api.modules.health') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.health') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Health</a>
               </div>
               <div>
+                <a href="{{ route('marketing.docs.api.modules.hygiene') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.hygiene') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Hygiene</a>
+              </div>
+              <div>
                 <a href="{{ route('marketing.docs.api.modules.energy') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.energy') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Energy</a>
               </div>
               <div>

--- a/resources/views/marketing/docs/api/modules/hygiene.blade.php
+++ b/resources/views/marketing/docs/api/modules/hygiene.blade.php
@@ -1,0 +1,65 @@
+<x-marketing-docs-layout :breadcrumbItems="[
+  ['label' => 'Home', 'route' => route('marketing.index')],
+  ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],
+  ['label' => 'Modules'],
+  ['label' => 'Hygiene'],
+]">
+  <div class="py-16">
+    <x-marketing.docs.h1 title="Hygiene module" />
+
+    <x-marketing.docs.table-of-content :items="[
+      [
+        'id' => 'log-hygiene',
+        'title' => 'Log hygiene',
+      ],
+    ]" />
+
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2 dark:border-gray-700">
+      <div>
+        <p class="mb-2">The hygiene module endpoint lets you log daily hygiene activities for a specific day.</p>
+        <p class="mb-2">The endpoint returns the updated journal entry.</p>
+      </div>
+      <div>
+        <x-marketing.docs.code title="Endpoints">
+          <div class="flex flex-col gap-y-2">
+            <a href="#log-hygiene">
+              <span class="text-orange-500">PUT</span>
+              /api/journals/{id}/{year}/{month}/{day}/hygiene
+            </a>
+          </div>
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/journals/{id}/{year}/{month}/{day}/hygiene -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="log-hygiene" title="Log hygiene" />
+        <p class="mb-10">This endpoint logs hygiene details for a specific day on a journal entry.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute required name="year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute required name="month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute required name="day" type="integer" description="The day of the journal entry." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute required name="showered" type="string" description="Whether you showered. Accepted values are: yes, no." />
+          <x-marketing.docs.attribute required name="brushed_teeth" type="string" description="When you brushed your teeth. Accepted values are: no, am, pm." />
+          <x-marketing.docs.attribute required name="skincare" type="string" description="Whether you did skincare. Accepted values are: yes, no." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/hygiene" verb="PUT" verbClass="text-yellow-700">
+          @include('marketing.docs.api.partials.journal-entry-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+  </div>
+</x-marketing-docs-layout>

--- a/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
@@ -32,6 +32,10 @@
   <x-marketing.docs.attribute name="attributes.modules.primary_obligation.primary_obligation" type="string" description="What demanded most of your attention." />
   <x-marketing.docs.attribute name="attributes.modules.health" type="object" description="The health module payload." />
   <x-marketing.docs.attribute name="attributes.modules.health.health" type="string" description="How you felt on that day." />
+  <x-marketing.docs.attribute name="attributes.modules.hygiene" type="object" description="The hygiene module payload." />
+  <x-marketing.docs.attribute name="attributes.modules.hygiene.showered" type="string" description="Whether you showered." />
+  <x-marketing.docs.attribute name="attributes.modules.hygiene.brushed_teeth" type="string" description="When you brushed your teeth." />
+  <x-marketing.docs.attribute name="attributes.modules.hygiene.skincare" type="string" description="Whether you did skincare." />
   <x-marketing.docs.attribute name="attributes.modules.mood" type="object" description="The mood module payload." />
   <x-marketing.docs.attribute name="attributes.modules.mood.mood" type="string" description="The mood for that day." />
   <x-marketing.docs.attribute name="attributes.modules.energy" type="object" description="The energy module payload." />

--- a/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
@@ -130,6 +130,22 @@
   <span class="text-lime-700">"good"</span>
 </div>
 <div class="pl-16">},</div>
+<div class="pl-16">"hygiene": {</div>
+<div class="pl-20">
+  "showered":
+  <span class="text-lime-700">"yes"</span>
+  ,
+</div>
+<div class="pl-20">
+  "brushed_teeth":
+  <span class="text-lime-700">"am"</span>
+  ,
+</div>
+<div class="pl-20">
+  "skincare":
+  <span class="text-lime-700">"no"</span>
+</div>
+<div class="pl-16">},</div>
 <div class="pl-16">"mood": {</div>
 <div class="pl-20">
   "mood":

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\Journals\JournalEntryController;
 use App\Http\Controllers\Api\Journals\Modules\DayType\DayTypeController;
 use App\Http\Controllers\Api\Journals\Modules\Energy\EnergyController as EnergyModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Health\HealthController as HealthModuleController;
+use App\Http\Controllers\Api\Journals\Modules\Hygiene\HygieneController as HygieneModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Kids\KidsController as KidsModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Mood\MoodController as MoodModuleController;
 use App\Http\Controllers\Api\Journals\Modules\PhysicalActivity\PhysicalActivityController;
@@ -126,6 +127,9 @@ Route::name('api.')->group(function (): void {
 
                         Route::put('health', [HealthModuleController::class, 'update'])
                             ->name('journal.entry.health.update');
+
+                        Route::put('hygiene', [HygieneModuleController::class, 'update'])
+                            ->name('journal.entry.hygiene.update');
 
                         Route::put('mood', [MoodModuleController::class, 'update'])
                             ->name('journal.entry.mood.update');

--- a/routes/marketing.php
+++ b/routes/marketing.php
@@ -25,6 +25,7 @@ Route::middleware(['marketing'])->group(function (): void {
     Route::get('/docs/api/modules/day-type', [Docs\Api\Modules\DayTypeController::class, 'index'])->name('marketing.docs.api.modules.day-type');
     Route::get('/docs/api/modules/energy', [Docs\Api\Modules\EnergyController::class, 'index'])->name('marketing.docs.api.modules.energy');
     Route::get('/docs/api/modules/health', [Docs\Api\Modules\HealthController::class, 'index'])->name('marketing.docs.api.modules.health');
+    Route::get('/docs/api/modules/hygiene', [Docs\Api\Modules\HygieneController::class, 'index'])->name('marketing.docs.api.modules.hygiene');
     Route::get('/docs/api/modules/kids', [Docs\Api\Modules\KidsController::class, 'index'])->name('marketing.docs.api.modules.kids');
     Route::get('/docs/api/modules/mood', [Docs\Api\Modules\MoodController::class, 'index'])->name('marketing.docs.api.modules.mood');
     Route::get('/docs/api/modules/shopping', [Docs\Api\Modules\ShoppingController::class, 'index'])->name('marketing.docs.api.modules.shopping');

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,6 +103,10 @@ Route::middleware(['auth', 'verified', 'throttle:60,1', 'set.locale'])->group(fu
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/health', [Journals\Modules\Health\HealthController::class, 'update'])->name('journal.entry.health.update');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/health/reset', [Journals\Modules\Health\HealthResetController::class, 'update'])->name('journal.entry.health.reset');
 
+                // hygiene
+                Route::put('journals/{slug}/entries/{year}/{month}/{day}/hygiene', [Journals\Modules\Hygiene\HygieneController::class, 'update'])->name('journal.entry.hygiene.update');
+                Route::put('journals/{slug}/entries/{year}/{month}/{day}/hygiene/reset', [Journals\Modules\Hygiene\HygieneResetController::class, 'update'])->name('journal.entry.hygiene.reset');
+
                 // mood
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/mood', [Journals\Modules\Mood\MoodController::class, 'update'])->name('journal.entry.mood.update');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/mood/reset', [Journals\Modules\Mood\MoodResetController::class, 'update'])->name('journal.entry.mood.reset');

--- a/tests/Feature/Controllers/Api/Journals/Modules/Hygiene/HygieneControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Hygiene/HygieneControllerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Modules\Hygiene;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HygieneControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_hygiene_with_showered_and_returns_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'showered' => 'yes',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'attributes' => [
+                    'modules' => [
+                        'hygiene' => [
+                            'showered' => 'yes',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('yes', $entry->moduleHygiene->showered);
+    }
+
+    #[Test]
+    public function it_updates_hygiene_with_brushed_teeth_and_returns_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'brushed_teeth' => 'pm',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'attributes' => [
+                    'modules' => [
+                        'hygiene' => [
+                            'brushed_teeth' => 'pm',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('pm', $entry->moduleHygiene->brushed_teeth);
+    }
+
+    #[Test]
+    public function it_updates_hygiene_with_skincare_and_returns_journal_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'skincare' => 'no',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'data' => [
+                'attributes' => [
+                    'modules' => [
+                        'hygiene' => [
+                            'skincare' => 'no',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('no', $entry->moduleHygiene->skincare);
+    }
+
+    #[Test]
+    public function it_validates_hygiene_must_be_valid(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'showered' => 'maybe',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('showered');
+    }
+
+    #[Test]
+    public function it_validates_hygiene_is_required(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['showered', 'brushed_teeth', 'skincare']);
+    }
+
+    #[Test]
+    public function it_requires_authentication(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'showered' => 'yes',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->json('PUT', "/api/journals/{$journal->id}/2024/6/15/hygiene", [
+            'showered' => 'yes',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/App/Journals/Modules/Hygiene/HygieneControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Hygiene/HygieneControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\App\Journals\Modules\Hygiene;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HygieneControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_hygiene_with_showered_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            ['showered' => 'yes'],
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/6/15");
+        $response->assertSessionHas('status');
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('yes', $entry->moduleHygiene->showered);
+    }
+
+    #[Test]
+    public function it_updates_hygiene_with_brushed_teeth_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            ['brushed_teeth' => 'am'],
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/6/15");
+        $response->assertSessionHas('status');
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('am', $entry->moduleHygiene->brushed_teeth);
+    }
+
+    #[Test]
+    public function it_updates_hygiene_with_skincare_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            ['skincare' => 'no'],
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/6/15");
+        $response->assertSessionHas('status');
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertEquals('no', $entry->moduleHygiene->skincare);
+    }
+
+    #[Test]
+    public function it_validates_hygiene_values_must_be_valid(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            ['showered' => 'maybe'],
+        );
+
+        $response->assertSessionHasErrors('showered');
+    }
+
+    #[Test]
+    public function it_validates_hygiene_is_required(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            [],
+        );
+
+        $response->assertSessionHasErrors(['showered', 'brushed_teeth', 'skincare']);
+    }
+
+    #[Test]
+    public function it_redirects_guests_to_login(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->put("/journals/{$journal->slug}/entries/2024/6/15/hygiene", [
+            'showered' => 'yes',
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/hygiene",
+            ['showered' => 'yes'],
+        );
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/Controllers/App/Journals/Modules/Hygiene/HygieneResetControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Hygiene/HygieneResetControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\App\Journals\Modules\Hygiene;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HygieneResetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_hygiene_data_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2022/1/1/hygiene/reset",
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2022/1/1");
+        $response->assertSessionHas('status');
+
+        $entry->refresh()->load('moduleHygiene');
+        $this->assertNull($entry->moduleHygiene);
+    }
+
+    #[Test]
+    public function it_redirects_guests_to_login(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->put("/journals/{$journal->slug}/entries/2022/1/1/hygiene/reset");
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'no',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2022/1/1/hygiene/reset",
+        );
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/Controllers/App/Journals/Settings/JournalModulesControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Settings/JournalModulesControllerTest.php
@@ -256,6 +256,48 @@ final class JournalModulesControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_toggles_hygiene_module_from_enabled_to_disabled(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+            'show_hygiene_module' => true,
+        ]);
+
+        $response = $this->actingAs($user)->put('/journals/' . $journal->slug . '/settings/modules', [
+            'module' => 'hygiene',
+        ]);
+
+        $response->assertRedirect('/journals/' . $journal->slug . '/settings/modules');
+
+        $this->assertDatabaseHas('journals', [
+            'id' => $journal->id,
+            'show_hygiene_module' => false,
+        ]);
+    }
+
+    #[Test]
+    public function it_toggles_hygiene_module_from_disabled_to_enabled(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+            'show_hygiene_module' => false,
+        ]);
+
+        $response = $this->actingAs($user)->put('/journals/' . $journal->slug . '/settings/modules', [
+            'module' => 'hygiene',
+        ]);
+
+        $response->assertRedirect('/journals/' . $journal->slug . '/settings/modules');
+
+        $this->assertDatabaseHas('journals', [
+            'id' => $journal->id,
+            'show_hygiene_module' => true,
+        ]);
+    }
+
+    #[Test]
     public function it_toggles_mood_module_from_enabled_to_disabled(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Controllers/Marketing/Docs/Api/Modules/HygieneControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/Docs/Api/Modules/HygieneControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HygieneControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_hygiene_module_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.modules.hygiene', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.modules.hygiene');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.modules.hygiene';
+        });
+    }
+}

--- a/tests/Unit/Actions/LogHygieneTest.php
+++ b/tests/Unit/Actions/LogHygieneTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\LogHygiene;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class LogHygieneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_logs_hygiene_with_showered(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $result = (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: 'yes',
+            brushedTeeth: null,
+            skincare: null,
+        ))->execute();
+
+        $this->assertEquals('yes', $result->moduleHygiene->showered);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'hygiene_logged' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_logs_hygiene_with_brushed_teeth(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $result = (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: null,
+            brushedTeeth: 'am',
+            skincare: null,
+        ))->execute();
+
+        $this->assertEquals('am', $result->moduleHygiene->brushed_teeth);
+    }
+
+    #[Test]
+    public function it_logs_hygiene_with_skincare(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $result = (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: null,
+            brushedTeeth: null,
+            skincare: 'no',
+        ))->execute();
+
+        $this->assertEquals('no', $result->moduleHygiene->skincare);
+    }
+
+    #[Test]
+    public function it_throws_validation_exception_for_invalid_hygiene_value(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: 'maybe',
+            brushedTeeth: null,
+            skincare: null,
+        ))->execute();
+    }
+
+    #[Test]
+    public function it_throws_validation_exception_when_no_values_provided(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: null,
+            brushedTeeth: null,
+            skincare: null,
+        ))->execute();
+    }
+
+    #[Test]
+    public function it_throws_exception_when_user_does_not_own_journal(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $user = User::factory()->create();
+        $anotherUser = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $anotherUser->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        (new LogHygiene(
+            user: $user,
+            entry: $entry,
+            showered: 'yes',
+            brushedTeeth: null,
+            skincare: null,
+        ))->execute();
+    }
+}

--- a/tests/Unit/Actions/ResetHygieneDataTest.php
+++ b/tests/Unit/Actions/ResetHygieneDataTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\ResetHygieneData;
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ResetHygieneDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_hygiene_data_for_a_journal_entry(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
+        ]);
+
+        $result = (new ResetHygieneData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+
+        $this->assertNull($result->moduleHygiene);
+
+        $this->assertDatabaseMissing('module_hygiene', [
+            'journal_entry_id' => $entry->id,
+        ]);
+
+        $this->assertInstanceOf(JournalEntry::class, $result);
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user): bool {
+                return $job->action === 'hygiene_reset' && $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: CheckPresenceOfContentInJournalEntry::class,
+            callback: function (CheckPresenceOfContentInJournalEntry $job) use ($entry): bool {
+                return $job->entry->id === $entry->id;
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_when_entry_does_not_belong_to_user(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Journal entry not found');
+
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $otherUser->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        (new ResetHygieneData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+    }
+}

--- a/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
+++ b/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Models\Journal;
 use App\Models\JournalEntry;
 use App\Models\ModuleKids;
+use App\Models\ModuleHygiene;
 use App\Models\ModulePhysicalActivity;
 use App\Models\ModulePrimaryObligation;
 use App\Models\ModuleShopping;
@@ -136,6 +137,27 @@ final class CheckPresenceOfContentInJournalEntryTest extends TestCase
         ModulePrimaryObligation::factory()->create([
             'journal_entry_id' => $entry->id,
             'primary_obligation' => 'work',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_hygiene_module_has_data(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
         ]);
 
         $job = new CheckPresenceOfContentInJournalEntry($entry);

--- a/tests/Unit/Jobs/DeleteRelatedJournalDataTest.php
+++ b/tests/Unit/Jobs/DeleteRelatedJournalDataTest.php
@@ -12,6 +12,7 @@ use App\Models\Log;
 use App\Models\ModuleDayType;
 use App\Models\ModuleEnergy;
 use App\Models\ModuleHealth;
+use App\Models\ModuleHygiene;
 use App\Models\ModuleKids;
 use App\Models\ModuleMood;
 use App\Models\ModulePhysicalActivity;
@@ -54,6 +55,9 @@ final class DeleteRelatedJournalDataTest extends TestCase
             'journal_entry_id' => $entry->id,
         ]);
         ModuleHealth::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+        ModuleHygiene::factory()->create([
             'journal_entry_id' => $entry->id,
         ]);
         ModuleMood::factory()->create([
@@ -102,6 +106,9 @@ final class DeleteRelatedJournalDataTest extends TestCase
             'journal_entry_id' => $entry->id,
         ]);
         $this->assertDatabaseMissing('module_health', [
+            'journal_entry_id' => $entry->id,
+        ]);
+        $this->assertDatabaseMissing('module_hygiene', [
             'journal_entry_id' => $entry->id,
         ]);
         $this->assertDatabaseMissing('module_mood', [
@@ -172,6 +179,9 @@ final class DeleteRelatedJournalDataTest extends TestCase
             ModuleWork::factory()->create([
                 'journal_entry_id' => $entry->id,
             ]);
+            ModuleHygiene::factory()->create([
+                'journal_entry_id' => $entry->id,
+            ]);
             ModuleSexualActivity::factory()->create([
                 'journal_entry_id' => $entry->id,
             ]);
@@ -200,6 +210,9 @@ final class DeleteRelatedJournalDataTest extends TestCase
                 'journal_entry_id' => $entry->id,
             ]);
             $this->assertDatabaseMissing('module_work', [
+                'journal_entry_id' => $entry->id,
+            ]);
+            $this->assertDatabaseMissing('module_hygiene', [
                 'journal_entry_id' => $entry->id,
             ]);
             $this->assertDatabaseMissing('module_sexual_activity', [
@@ -245,6 +258,12 @@ final class DeleteRelatedJournalDataTest extends TestCase
             'journal_entry_id' => $entry1->id,
         ]);
         ModuleEnergy::factory()->create([
+            'journal_entry_id' => $entry2->id,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry1->id,
+        ]);
+        ModuleHygiene::factory()->create([
             'journal_entry_id' => $entry2->id,
         ]);
         ModuleSexualActivity::factory()->create([
@@ -300,6 +319,12 @@ final class DeleteRelatedJournalDataTest extends TestCase
             'journal_entry_id' => $entry1->id,
         ]);
         $this->assertDatabaseHas('module_energy', [
+            'journal_entry_id' => $entry2->id,
+        ]);
+        $this->assertDatabaseMissing('module_hygiene', [
+            'journal_entry_id' => $entry1->id,
+        ]);
+        $this->assertDatabaseHas('module_hygiene', [
             'journal_entry_id' => $entry2->id,
         ]);
         $this->assertDatabaseMissing('module_sexual_activity', [

--- a/tests/Unit/Models/JournalEntryTest.php
+++ b/tests/Unit/Models/JournalEntryTest.php
@@ -9,6 +9,7 @@ use App\Models\Book;
 use App\Models\Journal;
 use App\Models\JournalEntry;
 use App\Models\ModuleHealth;
+use App\Models\ModuleHygiene;
 use App\Models\ModuleDayType;
 use App\Models\ModuleEnergy;
 use App\Models\ModulePhysicalActivity;
@@ -140,6 +141,23 @@ final class JournalEntryTest extends TestCase
         $this->assertTrue($entry->moduleHealth()->exists());
         $this->assertEquals($moduleHealth->id, $entry->moduleHealth->id);
         $this->assertEquals('okay', $entry->moduleHealth->health);
+    }
+
+    #[Test]
+    public function it_has_one_module_hygiene(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        $moduleHygiene = ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
+        ]);
+
+        $this->assertTrue($entry->moduleHygiene()->exists());
+        $this->assertEquals($moduleHygiene->id, $entry->moduleHygiene->id);
+        $this->assertEquals('yes', $entry->moduleHygiene->showered);
     }
 
     #[Test]

--- a/tests/Unit/Models/ModuleHygieneTest.php
+++ b/tests/Unit/Models/ModuleHygieneTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ModuleHygieneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_belongs_to_a_journal_entry(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        $moduleHygiene = ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+
+        $this->assertTrue($moduleHygiene->entry()->exists());
+        $this->assertEquals($entry->id, $moduleHygiene->entry->id);
+    }
+}

--- a/tests/Unit/Presenters/HygieneModulePresenterTest.php
+++ b/tests/Unit/Presenters/HygieneModulePresenterTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
+use App\View\Presenters\HygieneModulePresenter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HygieneModulePresenterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_builds_hygiene_module_data(): void
+    {
+        $journal = Journal::factory()->create([
+            'slug' => 'my-journal',
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 12,
+            'day' => 25,
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('hygiene_url', $result);
+        $this->assertArrayHasKey('showered_options', $result);
+        $this->assertArrayHasKey('brushed_teeth_options', $result);
+        $this->assertArrayHasKey('skincare_options', $result);
+        $this->assertArrayHasKey('reset_url', $result);
+        $this->assertArrayHasKey('display_reset', $result);
+    }
+
+    #[Test]
+    public function it_generates_correct_hygiene_url(): void
+    {
+        $journal = Journal::factory()->create([
+            'slug' => 'my-journal',
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 12,
+            'day' => 25,
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertStringContainsString($journal->slug, $result['hygiene_url']);
+        $this->assertStringContainsString('2024', $result['hygiene_url']);
+        $this->assertStringContainsString('12', $result['hygiene_url']);
+        $this->assertStringContainsString('25', $result['hygiene_url']);
+    }
+
+    #[Test]
+    public function it_generates_correct_reset_url(): void
+    {
+        $journal = Journal::factory()->create([
+            'slug' => 'my-journal',
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 12,
+            'day' => 25,
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertStringContainsString($journal->slug, $result['reset_url']);
+        $this->assertStringContainsString('2024', $result['reset_url']);
+        $this->assertStringContainsString('12', $result['reset_url']);
+        $this->assertStringContainsString('25', $result['reset_url']);
+    }
+
+    #[Test]
+    public function it_returns_all_hygiene_options(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertCount(2, $result['showered_options']);
+        $this->assertCount(3, $result['brushed_teeth_options']);
+        $this->assertCount(2, $result['skincare_options']);
+    }
+
+    #[Test]
+    public function it_marks_selected_hygiene_options(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
+            'brushed_teeth' => 'pm',
+            'skincare' => 'no',
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertTrue($result['showered_options'][0]['is_selected']);
+        $this->assertTrue($result['brushed_teeth_options'][2]['is_selected']);
+        $this->assertTrue($result['skincare_options'][1]['is_selected']);
+    }
+
+    #[Test]
+    public function it_displays_reset_when_hygiene_is_set(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleHygiene::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'showered' => 'yes',
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertTrue($result['display_reset']);
+    }
+
+    #[Test]
+    public function it_does_not_display_reset_when_no_hygiene_is_set(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $presenter = new HygieneModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertFalse($result['display_reset']);
+    }
+}

--- a/tests/Unit/Presenters/JournalEntryPresenterTest.php
+++ b/tests/Unit/Presenters/JournalEntryPresenterTest.php
@@ -34,6 +34,7 @@ final class JournalEntryPresenterTest extends TestCase
         $this->assertArrayHasKey('work', $result);
         $this->assertArrayHasKey('travel', $result);
         $this->assertArrayHasKey('day_type', $result);
+        $this->assertArrayHasKey('hygiene', $result);
         $this->assertArrayHasKey('sexual_activity', $result);
         $this->assertArrayHasKey('energy', $result);
     }


### PR DESCRIPTION
### Motivation

- Add a small focused Hygiene module for journal entries to capture daily hygiene: `showered` (yes/no), `brushed_teeth` (no/am/pm) and `skincare` (yes/no).  
- Provide the same UX surface and API experience as existing modules (health, mood, etc.) so hygiene can be logged via the web UI and API.  
- Ensure hygiene contributes to `has_content` and is cleaned up when a journal is deleted.

### Description

- Add persistence and schema changes with `ModuleHygiene` model, `ModuleHygieneFactory`, and migrations `create_module_hygiene` and `add_show_hygiene_module_to_journals_table`.  
- Implement actions `LogHygiene` and `ResetHygieneData`, web and API controllers for update/reset, a `HygieneModulePresenter`, a Blade partial `resources/views/app/journal/entry/partials/hygiene.blade.php`, and routes for web and API.  
- Wire module into the app by adding the `moduleHygiene()` relation to `JournalEntry`, `show_hygiene_module` to `Journal`, module output to `JournalEntryResource`, presence checks in `CheckPresenceOfContentInJournalEntry`, and deletion in `DeleteRelatedJournalData`.  
- Add unit and feature tests covering model relations, presenter, actions, controllers, API, job coverage, and settings toggling (multiple new `tests/Unit` and `tests/Feature` files).

### Testing

- Added automated tests for the hygiene module (unit and feature) including `tests/Unit/Actions/LogHygieneTest.php`, `tests/Unit/Actions/ResetHygieneDataTest.php`, and API + web controller tests for hygiene; these tests were created but not executed in CI here.  
- Attempted to run the formatter with `vendor/bin/pint --dirty`, but it failed because `vendor/bin/pint` (project dependencies) were not available in the environment.  
- Attempted to run a focused PHPUnit invocation with `php artisan test <files>`, but it failed because `vendor/autoload.php` was missing (dependencies not installed).  
- The repository changes were committed; please run `composer install` (or `composer journalos:unit`) locally or in CI and then run the added tests to verify all passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e6d5c3c883209da92b177a154dca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Hygiene Module (PR #149)

**New Features:**
- Added Hygiene module to capture daily hygiene tracking with three data fields:
  - Showered (yes/no)
  - Brushed teeth (no/am/pm)
  - Skincare (yes/no)
- Hygiene module can be toggled on/off in journal settings (Body & Health section)

**User Interface & API:**
- Web UI with segmented controls for updating hygiene entries
- API endpoint for hygiene updates (`PUT /api/journals/{id}/{year}/{month}/{day}/hygiene`)
- Reset functionality to clear hygiene data for a specific journal entry
- Hygiene data included in JSON API responses via `JournalEntryResource`

**Integration:**
- Hygiene entries contribute to journal content presence detection
- Hygiene data automatically deleted when journal entries are removed
- Encrypted storage for hygiene field values
- User action logging for hygiene updates and resets

**Technical Implementation:**
- `ModuleHygiene` model with `HasOne` relationship from `JournalEntry`
- `LogHygiene` and `ResetHygieneData` action classes for business logic
- Web and API controllers for managing hygiene data
- `HygieneModulePresenter` for rendering hygiene module UI
- Database migrations with encrypted text fields
- Factory for testing

**Testing:**
- Comprehensive unit and feature test coverage added (tests not executed in CI due to missing dependencies; run `composer install` to execute)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->