### PR TITLE
fix: avoid typeerror for nullable physical activity inputs

### DIFF
--- a/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
@@ -31,7 +31,7 @@ final class PhysicalActivityController extends Controller
             $entry = new LogHasDonePhysicalActivity(
                 user: Auth::user(),
                 entry: $entry,
-                hasDonePhysicalActivity: TextSanitizer::plainText($validated['has_done_physical_activity']),
+                hasDonePhysicalActivity: TextSanitizer::nullablePlainText($validated['has_done_physical_activity']),
             )->execute();
         }
 
@@ -40,7 +40,7 @@ final class PhysicalActivityController extends Controller
             $entry = new LogActivityType(
                 user: Auth::user(),
                 entry: $entry,
-                activityType: TextSanitizer::plainText($validated['activity_type']),
+                activityType: TextSanitizer::nullablePlainText($validated['activity_type']),
             )->execute();
         }
 
@@ -49,7 +49,7 @@ final class PhysicalActivityController extends Controller
             $entry = new LogActivityIntensity(
                 user: Auth::user(),
                 entry: $entry,
-                activityIntensity: TextSanitizer::plainText($validated['activity_intensity']),
+                activityIntensity: TextSanitizer::nullablePlainText($validated['activity_intensity']),
             )->execute();
         }
 


### PR DESCRIPTION
### Motivation

- Prevent a `TypeError` when nullable physical activity fields are passed through the sanitizer.  
- Ensure the API controller preserves existing module values when clients send explicit `null` for optional fields.  
- Provide automated test coverage that verifies `null` fields are ignored and do not clear stored data.  

### Description

- Replace `TextSanitizer::plainText` with `TextSanitizer::nullablePlainText` for `has_done_physical_activity`, `activity_type`, and `activity_intensity` in `app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php`.  
- Add test `it_ignores_nullable_fields_when_they_are_null` to `tests/Feature/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityControllerTest.php` to assert that sending `null` does not overwrite existing `ModulePhysicalActivity` values.  
- Import `ModulePhysicalActivity` in the test file and seed an existing module record to assert values remain unchanged.  

### Testing

- Ran `vendor/bin/pint --dirty` (failed: `vendor/bin/pint` not found).  
- Ran `php artisan test tests/Feature/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityControllerTest.php` (failed: `vendor/autoload.php` missing).  
- Ran `composer journalos:unit` (failed: `vendor/autoload.php` missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ed32cbf48320b61e54400e75bee8)