### PR TITLE
chore: remove settings breadcrumb from journal modules index view

### DIFF
--- a/resources/views/app/journal/settings/modules/index.blade.php
+++ b/resources/views/app/journal/settings/modules/index.blade.php
@@ -6,7 +6,6 @@
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],
     ['label' => $journal->name, 'route' => route('journal.show', ['slug' => $journal->slug]) ],
-    ['label' => __('Settings'), 'route' => route('journal.settings.modules.index', ['slug' => $journal->slug])],
     ['label' => __('Modules')]
   ]" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Removed Settings breadcrumb from the journal modules index view
- Breadcrumb navigation now displays only Dashboard, journal name, and Modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->