### PR TITLE
test: fake queue in action unit tests

### DIFF
--- a/tests/Unit/Actions/ClaimAccountTest.php
+++ b/tests/Unit/Actions/ClaimAccountTest.php
@@ -19,10 +19,16 @@ final class ClaimAccountTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_claims_a_guest_account(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::create(2025, 12, 16, 9, 0, 0));
 
         $guest = User::factory()->create([

--- a/tests/Unit/Actions/CreateAccountTest.php
+++ b/tests/Unit/Actions/CreateAccountTest.php
@@ -19,10 +19,16 @@ final class CreateAccountTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_an_account(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
 
         $user = (new CreateAccount(

--- a/tests/Unit/Actions/CreateApiKeyTest.php
+++ b/tests/Unit/Actions/CreateApiKeyTest.php
@@ -18,11 +18,16 @@ final class CreateApiKeyTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_an_api_key(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
 
         (new CreateApiKey(

--- a/tests/Unit/Actions/CreateBookTest.php
+++ b/tests/Unit/Actions/CreateBookTest.php
@@ -18,11 +18,16 @@ final class CreateBookTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_a_book(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
 
         $book = (new CreateBook(
@@ -60,8 +65,6 @@ final class CreateBookTest extends TestCase
     #[Test]
     public function it_allows_duplicate_book_names_for_same_user(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
 
         $book1 = (new CreateBook(
@@ -82,8 +85,6 @@ final class CreateBookTest extends TestCase
     #[Test]
     public function it_allows_same_book_name_for_different_users(): void
     {
-        Queue::fake();
-
         $user1 = User::factory()->create();
         $user2 = User::factory()->create();
 

--- a/tests/Unit/Actions/CreateEmailSentTest.php
+++ b/tests/Unit/Actions/CreateEmailSentTest.php
@@ -18,11 +18,16 @@ final class CreateEmailSentTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_an_email_sent(): void
     {
-        Queue::fake();
-
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
         $user = User::factory()->create();
 
@@ -54,8 +59,6 @@ final class CreateEmailSentTest extends TestCase
     #[Test]
     public function it_sanitizes_the_body_and_strips_any_links(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
 
         $emailSent = (new CreateEmailSent(
@@ -76,8 +79,6 @@ final class CreateEmailSentTest extends TestCase
     #[Test]
     public function it_creates_an_email_sent_with_a_uuid(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $uuid = Str::uuid();
 

--- a/tests/Unit/Actions/CreateGuestAccountTest.php
+++ b/tests/Unit/Actions/CreateGuestAccountTest.php
@@ -19,10 +19,16 @@ final class CreateGuestAccountTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_a_guest_account(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::create(2025, 12, 16));
 
         $user = (new CreateGuestAccount())->execute();
@@ -64,8 +70,6 @@ final class CreateGuestAccountTest extends TestCase
     #[Test]
     public function it_creates_first_journal_for_guest(): void
     {
-        Queue::fake();
-
         $user = (new CreateGuestAccount())->execute();
 
         $this->assertDatabaseHas('journals', [
@@ -87,8 +91,6 @@ final class CreateGuestAccountTest extends TestCase
     #[Test]
     public function it_creates_unique_email_for_each_guest(): void
     {
-        Queue::fake();
-
         $user1 = (new CreateGuestAccount())->execute();
         $user2 = (new CreateGuestAccount())->execute();
 
@@ -100,7 +102,6 @@ final class CreateGuestAccountTest extends TestCase
     #[Test]
     public function it_sets_guest_expiration_to_seven_days(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::create(2025, 12, 16, 14, 30, 0));
 
         $user = (new CreateGuestAccount())->execute();

--- a/tests/Unit/Actions/CreateJournalTest.php
+++ b/tests/Unit/Actions/CreateJournalTest.php
@@ -20,10 +20,16 @@ final class CreateJournalTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_a_journal(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::parse('2025-03-17 10:00:00'));
 
         $user = User::factory()->create();

--- a/tests/Unit/Actions/CreateMagicLinkTest.php
+++ b/tests/Unit/Actions/CreateMagicLinkTest.php
@@ -17,11 +17,16 @@ final class CreateMagicLinkTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_returns_a_string(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'email' => 'test@example.com',
         ]);
@@ -44,8 +49,6 @@ final class CreateMagicLinkTest extends TestCase
     #[Test]
     public function it_contains_the_app_url_with_magic_link_structure(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'email' => 'test@example.com',
         ]);
@@ -62,8 +65,6 @@ final class CreateMagicLinkTest extends TestCase
     #[Test]
     public function it_throws_an_exception_if_user_not_found(): void
     {
-        Queue::fake();
-
         $nonExistentEmail = 'nonexistent@example.com';
 
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Unit/Actions/CreateOrRetrieveJournalEntryTest.php
+++ b/tests/Unit/Actions/CreateOrRetrieveJournalEntryTest.php
@@ -21,11 +21,16 @@ final class CreateOrRetrieveJournalEntryTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_creates_an_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php
+++ b/tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Actions\DestroyAccountAsInstanceAdministrator;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -18,6 +19,8 @@ final class DestroyAccountAsInstanceAdministratorTest extends TestCase
     #[Test]
     public function it_destroys_an_account_as_instance_administrator(): void
     {
+        Queue::fake();
+
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => true,
@@ -36,6 +39,8 @@ final class DestroyAccountAsInstanceAdministratorTest extends TestCase
     #[Test]
     public function it_fails_if_user_is_not_instance_administrator(): void
     {
+        Queue::fake();
+
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => false,

--- a/tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php
+++ b/tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php
@@ -16,11 +16,16 @@ final class DestroyAccountAsInstanceAdministratorTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_destroys_an_account_as_instance_administrator(): void
     {
-        Queue::fake();
-
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => true,
@@ -39,8 +44,6 @@ final class DestroyAccountAsInstanceAdministratorTest extends TestCase
     #[Test]
     public function it_fails_if_user_is_not_instance_administrator(): void
     {
-        Queue::fake();
-
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => false,

--- a/tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php
+++ b/tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php
@@ -9,6 +9,7 @@ use App\Mail\AccountAutomaticallyDestroyed;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,6 +21,7 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
     public function it_destroys_an_inactive_account(): void
     {
         Mail::fake();
+        Queue::fake();
         config(['journalos.account_deletion_notification_email' => 'admin@journalos.cloud']);
 
         $user = User::factory()->create([
@@ -44,6 +46,7 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
     public function it_does_not_destroy_a_recently_active_account(): void
     {
         Mail::fake();
+        Queue::fake();
 
         $user = User::factory()->create([
             'last_activity_at' => now()->subMonths(3),
@@ -64,6 +67,7 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
     public function it_does_not_destroy_account_without_activity_record(): void
     {
         Mail::fake();
+        Queue::fake();
 
         $user = User::factory()->create([
             'last_activity_at' => null,

--- a/tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php
+++ b/tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php
@@ -17,11 +17,17 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_destroys_an_inactive_account(): void
     {
         Mail::fake();
-        Queue::fake();
         config(['journalos.account_deletion_notification_email' => 'admin@journalos.cloud']);
 
         $user = User::factory()->create([
@@ -46,7 +52,6 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
     public function it_does_not_destroy_a_recently_active_account(): void
     {
         Mail::fake();
-        Queue::fake();
 
         $user = User::factory()->create([
             'last_activity_at' => now()->subMonths(3),
@@ -67,7 +72,6 @@ final class DestroyAccountBecauseInactivityTest extends TestCase
     public function it_does_not_destroy_account_without_activity_record(): void
     {
         Mail::fake();
-        Queue::fake();
 
         $user = User::factory()->create([
             'last_activity_at' => null,

--- a/tests/Unit/Actions/DestroyAccountTest.php
+++ b/tests/Unit/Actions/DestroyAccountTest.php
@@ -18,11 +18,17 @@ final class DestroyAccountTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_destroys_a_user_account(): void
     {
         Mail::fake();
-        Queue::fake();
         config(['journalos.account_deletion_notification_email' => 'regis@journalos.cloud']);
 
         $user = User::factory()->create();

--- a/tests/Unit/Actions/DestroyApiKeyTest.php
+++ b/tests/Unit/Actions/DestroyApiKeyTest.php
@@ -18,11 +18,16 @@ final class DestroyApiKeyTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_deletes_an_api_key(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $user->createToken('Test API Key');
 

--- a/tests/Unit/Actions/DestroyBookTest.php
+++ b/tests/Unit/Actions/DestroyBookTest.php
@@ -19,11 +19,16 @@ final class DestroyBookTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_destroys_a_book(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $book = Book::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/DestroyJournalTest.php
+++ b/tests/Unit/Actions/DestroyJournalTest.php
@@ -21,11 +21,16 @@ final class DestroyJournalTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_deletes_a_journal(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/Generate2faQRCodeTest.php
+++ b/tests/Unit/Actions/Generate2faQRCodeTest.php
@@ -18,10 +18,16 @@ final class Generate2faQRCodeTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_generates_a_2fa_qr_code(): void
     {
-        Queue::fake();
         Carbon::setTestNow(Carbon::parse('2025-07-16 10:00:00'));
 
         $user = User::factory()->create([

--- a/tests/Unit/Actions/GenerateJournalAvatarTest.php
+++ b/tests/Unit/Actions/GenerateJournalAvatarTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions;
 
 use App\Actions\GenerateJournalAvatar;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -16,6 +17,8 @@ final class GenerateJournalAvatarTest extends TestCase
     #[Test]
     public function it_generates_a_base64_encoded_svg_avatar(): void
     {
+        Queue::fake();
+
         $generator = new GenerateJournalAvatar(
             seed: 'test-seed',
         );

--- a/tests/Unit/Actions/GenerateJournalAvatarTest.php
+++ b/tests/Unit/Actions/GenerateJournalAvatarTest.php
@@ -14,11 +14,16 @@ final class GenerateJournalAvatarTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_generates_a_base64_encoded_svg_avatar(): void
     {
-        Queue::fake();
-
         $generator = new GenerateJournalAvatar(
             seed: 'test-seed',
         );

--- a/tests/Unit/Actions/GenerateOrganizationAvatarTest.php
+++ b/tests/Unit/Actions/GenerateOrganizationAvatarTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Actions;
 
 use App\Actions\GenerateOrganizationAvatar;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -16,6 +17,8 @@ final class GenerateOrganizationAvatarTest extends TestCase
     #[Test]
     public function it_generates_a_base64_encoded_svg_avatar(): void
     {
+        Queue::fake();
+
         $generator = new GenerateOrganizationAvatar(
             seed: 'test-seed',
         );

--- a/tests/Unit/Actions/GenerateOrganizationAvatarTest.php
+++ b/tests/Unit/Actions/GenerateOrganizationAvatarTest.php
@@ -14,11 +14,16 @@ final class GenerateOrganizationAvatarTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_generates_a_base64_encoded_svg_avatar(): void
     {
-        Queue::fake();
-
         $generator = new GenerateOrganizationAvatar(
             seed: 'test-seed',
         );

--- a/tests/Unit/Actions/GiveFreeAccountTest.php
+++ b/tests/Unit/Actions/GiveFreeAccountTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Actions\GiveFreeAccount;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -18,6 +19,8 @@ final class GiveFreeAccountTest extends TestCase
     #[Test]
     public function it_gives_free_account_to_an_account(): void
     {
+        Queue::fake();
+
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => true,
@@ -37,6 +40,8 @@ final class GiveFreeAccountTest extends TestCase
     #[Test]
     public function it_fails_if_user_is_not_instance_administrator(): void
     {
+        Queue::fake();
+
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => false,

--- a/tests/Unit/Actions/GiveFreeAccountTest.php
+++ b/tests/Unit/Actions/GiveFreeAccountTest.php
@@ -16,11 +16,16 @@ final class GiveFreeAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_gives_free_account_to_an_account(): void
     {
-        Queue::fake();
-
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => true,
@@ -40,8 +45,6 @@ final class GiveFreeAccountTest extends TestCase
     #[Test]
     public function it_fails_if_user_is_not_instance_administrator(): void
     {
-        Queue::fake();
-
         $account = User::factory()->create();
         $user = User::factory()->create([
             'is_instance_admin' => false,

--- a/tests/Unit/Actions/LogBookTest.php
+++ b/tests/Unit/Actions/LogBookTest.php
@@ -23,11 +23,16 @@ final class LogBookTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_book_with_started_status(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -80,8 +85,6 @@ final class LogBookTest extends TestCase
     #[Test]
     public function it_logs_book_with_continued_status(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -110,8 +113,6 @@ final class LogBookTest extends TestCase
     #[Test]
     public function it_logs_book_with_finished_status(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogEnergyTest.php
+++ b/tests/Unit/Actions/LogEnergyTest.php
@@ -22,11 +22,16 @@ final class LogEnergyTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_energy_with_very_low(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogHadKidsTodayTest.php
+++ b/tests/Unit/Actions/LogHadKidsTodayTest.php
@@ -22,11 +22,16 @@ final class LogHadKidsTodayTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_kids_today_with_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogHasWorkedTest.php
+++ b/tests/Unit/Actions/LogHasWorkedTest.php
@@ -22,11 +22,16 @@ final class LogHasWorkedTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_has_worked_with_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -74,8 +79,6 @@ final class LogHasWorkedTest extends TestCase
     #[Test]
     public function it_logs_has_worked_with_no(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogHealthTest.php
+++ b/tests/Unit/Actions/LogHealthTest.php
@@ -22,11 +22,16 @@ final class LogHealthTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_health_with_good(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogHygieneTest.php
+++ b/tests/Unit/Actions/LogHygieneTest.php
@@ -22,11 +22,16 @@ final class LogHygieneTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_hygiene_with_showered(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogMoodTest.php
+++ b/tests/Unit/Actions/LogMoodTest.php
@@ -22,11 +22,16 @@ final class LogMoodTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_mood_with_terrible(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -71,8 +76,6 @@ final class LogMoodTest extends TestCase
     #[Test]
     public function it_logs_mood_with_bad(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -117,8 +120,6 @@ final class LogMoodTest extends TestCase
     #[Test]
     public function it_logs_mood_with_okay(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -163,8 +164,6 @@ final class LogMoodTest extends TestCase
     #[Test]
     public function it_logs_mood_with_good(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -209,8 +208,6 @@ final class LogMoodTest extends TestCase
     #[Test]
     public function it_logs_mood_with_great(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogNotesTest.php
+++ b/tests/Unit/Actions/LogNotesTest.php
@@ -21,11 +21,16 @@ final class LogNotesTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_notes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogPhysicalActivityTest.php
+++ b/tests/Unit/Actions/LogPhysicalActivityTest.php
@@ -22,11 +22,16 @@ final class LogPhysicalActivityTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_has_done_physical_activity_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogPrimaryObligationTest.php
+++ b/tests/Unit/Actions/LogPrimaryObligationTest.php
@@ -22,11 +22,16 @@ final class LogPrimaryObligationTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_primary_obligation_with_work(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogSexualActivityTest.php
+++ b/tests/Unit/Actions/LogSexualActivityTest.php
@@ -22,11 +22,16 @@ final class LogSexualActivityTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_had_sexual_activity_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogShoppingTest.php
+++ b/tests/Unit/Actions/LogShoppingTest.php
@@ -22,11 +22,16 @@ final class LogShoppingTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_has_shopped_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogSleepTest.php
+++ b/tests/Unit/Actions/LogSleepTest.php
@@ -23,11 +23,16 @@ final class LogSleepTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_bedtime(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogSocialDensityTest.php
+++ b/tests/Unit/Actions/LogSocialDensityTest.php
@@ -22,11 +22,16 @@ final class LogSocialDensityTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_social_density_with_alone(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogTravelTest.php
+++ b/tests/Unit/Actions/LogTravelTest.php
@@ -22,11 +22,16 @@ final class LogTravelTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_has_traveled_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogTypeOfDayTest.php
+++ b/tests/Unit/Actions/LogTypeOfDayTest.php
@@ -22,11 +22,16 @@ final class LogTypeOfDayTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_day_type_with_workday(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/LogWorkTest.php
+++ b/tests/Unit/Actions/LogWorkTest.php
@@ -22,11 +22,16 @@ final class LogWorkTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_logs_worked_yes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/PruneAccountTest.php
+++ b/tests/Unit/Actions/PruneAccountTest.php
@@ -18,11 +18,16 @@ final class PruneAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_prunes_an_account(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/RemoveBookTest.php
+++ b/tests/Unit/Actions/RemoveBookTest.php
@@ -24,11 +24,16 @@ final class RemoveBookTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_removes_book_from_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/RenameBookTest.php
+++ b/tests/Unit/Actions/RenameBookTest.php
@@ -19,11 +19,16 @@ final class RenameBookTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_renames_a_book(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $book = Book::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/RenameJournalTest.php
+++ b/tests/Unit/Actions/RenameJournalTest.php
@@ -20,11 +20,16 @@ final class RenameJournalTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_renames_a_journal(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetBookDataTest.php
+++ b/tests/Unit/Actions/ResetBookDataTest.php
@@ -24,11 +24,16 @@ final class ResetBookDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_book_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetDayTypeDataTest.php
+++ b/tests/Unit/Actions/ResetDayTypeDataTest.php
@@ -22,11 +22,16 @@ final class ResetDayTypeDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_day_type_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetEnergyDataTest.php
+++ b/tests/Unit/Actions/ResetEnergyDataTest.php
@@ -22,11 +22,16 @@ final class ResetEnergyDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_energy_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetHealthDataTest.php
+++ b/tests/Unit/Actions/ResetHealthDataTest.php
@@ -22,11 +22,16 @@ final class ResetHealthDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_health_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetHygieneDataTest.php
+++ b/tests/Unit/Actions/ResetHygieneDataTest.php
@@ -22,11 +22,16 @@ final class ResetHygieneDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_hygiene_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetKidsDataTest.php
+++ b/tests/Unit/Actions/ResetKidsDataTest.php
@@ -22,11 +22,16 @@ final class ResetKidsDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_kids_today_data(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetMoodDataTest.php
+++ b/tests/Unit/Actions/ResetMoodDataTest.php
@@ -22,11 +22,16 @@ final class ResetMoodDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_mood_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetNotesTest.php
+++ b/tests/Unit/Actions/ResetNotesTest.php
@@ -10,6 +10,7 @@ use App\Models\JournalEntry;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -20,6 +21,8 @@ final class ResetNotesTest extends TestCase
     #[Test]
     public function it_resets_notes(): void
     {
+        Queue::fake();
+
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -49,6 +52,8 @@ final class ResetNotesTest extends TestCase
     #[Test]
     public function it_throws_exception_if_entry_does_not_belong_to_user(): void
     {
+        Queue::fake();
+
         $user = User::factory()->create();
         $anotherUser = User::factory()->create();
         $journal = Journal::factory()->create([

--- a/tests/Unit/Actions/ResetNotesTest.php
+++ b/tests/Unit/Actions/ResetNotesTest.php
@@ -18,11 +18,16 @@ final class ResetNotesTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_notes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
@@ -52,8 +57,6 @@ final class ResetNotesTest extends TestCase
     #[Test]
     public function it_throws_exception_if_entry_does_not_belong_to_user(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $anotherUser = User::factory()->create();
         $journal = Journal::factory()->create([

--- a/tests/Unit/Actions/ResetPhysicalActivityDataTest.php
+++ b/tests/Unit/Actions/ResetPhysicalActivityDataTest.php
@@ -21,11 +21,16 @@ final class ResetPhysicalActivityDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_physical_activity_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetPrimaryObligationDataTest.php
+++ b/tests/Unit/Actions/ResetPrimaryObligationDataTest.php
@@ -22,11 +22,16 @@ final class ResetPrimaryObligationDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_primary_obligation_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetSexualActivityDataTest.php
+++ b/tests/Unit/Actions/ResetSexualActivityDataTest.php
@@ -22,11 +22,16 @@ final class ResetSexualActivityDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_sexual_activity_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetShoppingDataTest.php
+++ b/tests/Unit/Actions/ResetShoppingDataTest.php
@@ -22,11 +22,16 @@ final class ResetShoppingDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_shopping_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetSleepDataTest.php
+++ b/tests/Unit/Actions/ResetSleepDataTest.php
@@ -22,11 +22,16 @@ final class ResetSleepDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_sleep_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetSocialDensityDataTest.php
+++ b/tests/Unit/Actions/ResetSocialDensityDataTest.php
@@ -22,11 +22,16 @@ final class ResetSocialDensityDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_social_density_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetTravelDataTest.php
+++ b/tests/Unit/Actions/ResetTravelDataTest.php
@@ -22,11 +22,16 @@ final class ResetTravelDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_travel_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ResetWorkDataTest.php
+++ b/tests/Unit/Actions/ResetWorkDataTest.php
@@ -22,11 +22,16 @@ final class ResetWorkDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_resets_work_data_for_a_journal_entry(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/ToggleModuleVisibilityTest.php
+++ b/tests/Unit/Actions/ToggleModuleVisibilityTest.php
@@ -20,11 +20,16 @@ final class ToggleModuleVisibilityTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_toggles_a_module_visibility(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create();
         $journal = Journal::factory()->create([
             'user_id' => $user->id,

--- a/tests/Unit/Actions/UpdateTwoFAMethodTest.php
+++ b/tests/Unit/Actions/UpdateTwoFAMethodTest.php
@@ -17,11 +17,16 @@ final class UpdateTwoFAMethodTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_updates_user_2fa_method(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'two_factor_preferred_method' => 'email',
         ]);

--- a/tests/Unit/Actions/UpdateUserInformationTest.php
+++ b/tests/Unit/Actions/UpdateUserInformationTest.php
@@ -19,11 +19,16 @@ final class UpdateUserInformationTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_updates_user_information(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'first_name' => 'Ross',
             'last_name' => 'Geller',
@@ -73,7 +78,6 @@ final class UpdateUserInformationTest extends TestCase
     public function it_triggers_email_verification_when_email_changes(): void
     {
         Event::fake();
-        Queue::fake();
 
         $user = User::factory()->create([
             'email' => 'michael.scott@dundermifflin.com',
@@ -98,7 +102,6 @@ final class UpdateUserInformationTest extends TestCase
     public function it_does_not_trigger_email_verification_when_email_stays_same(): void
     {
         Event::fake();
-        Queue::fake();
 
         $user = User::factory()->create([
             'email' => 'michael.scott@dundermifflin.com',

--- a/tests/Unit/Actions/UpdateUserPasswordTest.php
+++ b/tests/Unit/Actions/UpdateUserPasswordTest.php
@@ -19,11 +19,16 @@ final class UpdateUserPasswordTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_updates_user_password(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'password' => Hash::make('current-password'),
         ]);

--- a/tests/Unit/Actions/Validate2faQRCodeTest.php
+++ b/tests/Unit/Actions/Validate2faQRCodeTest.php
@@ -19,11 +19,16 @@ final class Validate2faQRCodeTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_validates_the_2fa_qr_code_and_generates_recovery_codes(): void
     {
-        Queue::fake();
-
         $secret = 'JBSWY3DPEHPK3PXP';
 
         $user = User::factory()->create([
@@ -66,8 +71,6 @@ final class Validate2faQRCodeTest extends TestCase
     #[Test]
     public function it_throws_exception_when_token_is_invalid(): void
     {
-        Queue::fake();
-
         $secret = 'JBSWY3DPEHPK3PXP';
 
         $user = User::factory()->create([
@@ -98,8 +101,6 @@ final class Validate2faQRCodeTest extends TestCase
     #[Test]
     public function it_does_not_update_recovery_codes_when_token_is_invalid(): void
     {
-        Queue::fake();
-
         $secret = 'JBSWY3DPEHPK3PXP';
 
         $user = User::factory()->create([

--- a/tests/Unit/Actions/VerifyTwoFactorCodeTest.php
+++ b/tests/Unit/Actions/VerifyTwoFactorCodeTest.php
@@ -16,11 +16,16 @@ final class VerifyTwoFactorCodeTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     #[Test]
     public function it_verifies_a_rescue_code_and_updates_last_activity(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'two_factor_recovery_codes' => ['code-one', 'code-two'],
         ]);
@@ -45,8 +50,6 @@ final class VerifyTwoFactorCodeTest extends TestCase
     #[Test]
     public function it_returns_false_and_skips_activity_update_for_invalid_codes(): void
     {
-        Queue::fake();
-
         $user = User::factory()->create([
             'two_factor_recovery_codes' => ['code-one'],
         ]);


### PR DESCRIPTION
### Motivation

- Action classes dispatch jobs (`->dispatch(...)->onQueue('low')`) which can be executed during unit tests and cause unwanted side effects. 
- Tests that call actions directly should prevent real job dispatch to keep unit tests isolated and deterministic. 
- Add a consistent approach to fake the queue in action unit tests so jobs are asserted via `Queue::assert*` rather than executed. 

### Description

- Added `use Illuminate\Support\Facades\Queue;` and `Queue::fake();` at the start of affected tests to prevent real job dispatch. 
- Updated the following unit test files to fake the queue: `tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php`, `tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php`, `tests/Unit/Actions/GenerateJournalAvatarTest.php`, `tests/Unit/Actions/GenerateOrganizationAvatarTest.php`, `tests/Unit/Actions/GiveFreeAccountTest.php`, and `tests/Unit/Actions/ResetNotesTest.php`. 
- Kept tests' existing assertions unchanged and limited changes to test scaffolding only. 

### Testing

- Attempted to run the targeted PHPUnit tests with `php artisan test <files>` but the run failed due to missing `vendor/autoload.php` in the environment. (failed)
- Ran `vendor/bin/pint --dirty` to check formatting but it failed because `vendor/bin/pint` is not present in the environment. (failed)
- Local test tooling and formatter were not available in this sandbox; CI or a developer environment with dependencies installed should run `php artisan test` for the modified files and `vendor/bin/pint --dirty` to validate behavior and style.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963dc80d1c0832099f0d52d73f633e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add Queue faking to unit tests for action classes to prevent real job dispatch during testing.
- Updated these test files to import Illuminate\Support\Facades\Queue and call Queue::fake() in setUp():
  - tests/Unit/Actions/DestroyAccountAsInstanceAdministratorTest.php
  - tests/Unit/Actions/DestroyAccountBecauseInactivityTest.php
  - tests/Unit/Actions/GenerateJournalAvatarTest.php
  - tests/Unit/Actions/GenerateOrganizationAvatarTest.php
  - tests/Unit/Actions/GiveFreeAccountTest.php
  - tests/Unit/Actions/ResetNotesTest.php
- Tests can now assert job dispatch using Queue::assert* methods instead of executing real jobs.
- No changes to test logic or assertions; modifications are limited to test scaffolding.
- Note: Running tests or linters in CI or a developer environment with dependencies installed is required (local sandbox lacked vendor dependencies).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->