### PR TITLE
refactor: use Auth::user() in controller action payloads

### DIFF
--- a/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class DayTypeController extends Controller
 {
@@ -21,7 +22,7 @@ final class DayTypeController extends Controller
         ]);
 
         $entry = new LogTypeOfDay(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             dayType: TextSanitizer::plainText($validated['day_type']),
         )->execute();

--- a/app/Http/Controllers/Api/Journals/Modules/Kids/KidsController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Kids/KidsController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class KidsController extends Controller
 {
@@ -21,7 +22,7 @@ final class KidsController extends Controller
         ]);
 
         $entry = new LogHadKidsToday(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             hadKidsToday: TextSanitizer::plainText($validated['had_kids_today']),
         )->execute();

--- a/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class SexualActivityController extends Controller
 {
@@ -22,7 +23,7 @@ final class SexualActivityController extends Controller
         ]);
 
         $entry = new LogSexualActivity(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             hadSexualActivity: array_key_exists('had_sexual_activity', $validated)
                 ? TextSanitizer::nullablePlainText($validated['had_sexual_activity'])

--- a/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Sleep/SleepController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class SleepController extends Controller
 {
@@ -22,7 +23,7 @@ final class SleepController extends Controller
         ]);
 
         $entry = new LogSleep(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             bedtime: array_key_exists('bedtime', $validated)
                 ? TextSanitizer::nullablePlainText($validated['bedtime'])

--- a/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class TravelController extends Controller
 {
@@ -27,7 +28,7 @@ final class TravelController extends Controller
         ]);
 
         $entry = new LogTravel(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             hasTraveled: array_key_exists('has_traveled', $validated) ? TextSanitizer::nullablePlainText($validated['has_traveled']) : null,
             travelModes: array_key_exists('travel_modes', $validated)

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 final class WorkController extends Controller
 {
@@ -24,7 +25,7 @@ final class WorkController extends Controller
         ]);
 
         $entry = new LogWork(
-            user: $request->user(),
+            user: Auth::user(),
             entry: $journalEntry,
             worked: array_key_exists('worked', $validated) ? TextSanitizer::nullablePlainText($validated['worked']) : null,
             workMode: array_key_exists('work_mode', $validated) ? TextSanitizer::nullablePlainText($validated['work_mode']) : null,

--- a/app/Http/Controllers/App/Journals/JournalController.php
+++ b/app/Http/Controllers/App/Journals/JournalController.php
@@ -86,7 +86,7 @@ final class JournalController extends Controller
         ]);
 
         new RenameJournal(
-            user: $request->user(),
+            user: Auth::user(),
             journal: $journal,
             name: TextSanitizer::plainText($validated['journal_name']),
         )->execute();


### PR DESCRIPTION
### Motivation

- Standardize how the authenticated user is passed to Action objects by using `Auth::user()` everywhere instead of `$request->user()` to improve consistency.
- Reduce small differences between controllers that can hide bugs or code-review drift.

### Description

- Replaced `user: $request->user()` with `user: Auth::user()` in multiple controllers and added `use Illuminate\Support\Facades\Auth;` where needed.
- Updated the following files: `app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php`, `app/Http/Controllers/Api/Journals/Modules/Kids/KidsController.php`, `app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php`, `app/Http/Controllers/Api/Journals/Modules/Sleep/SleepController.php`, `app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php`, `app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php`, and `app/Http/Controllers/App/Journals/JournalController.php`.
- This is a refactor-only change with no intended behavioral changes to the actions themselves.

### Testing

- Ran `php artisan test tests/Feature/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityControllerTest.php` and it failed to run due to missing `vendor/autoload.php` in the environment.
- Ran `vendor/bin/pint --dirty` and it failed because `vendor/bin/pint` was not present in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963dcfb06088320b2b74d2759f046b4)