### PR TITLE
refactor: centralize module option constants

### DIFF
--- a/app/Actions/LogEnergy.php
+++ b/app/Actions/LogEnergy.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleEnergy;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -39,8 +40,7 @@ final readonly class LogEnergy
             throw new ModelNotFoundException('Journal entry not found');
         }
 
-        $validEnergyValues = ['very low', 'low', 'normal', 'high', 'very high'];
-        if (! in_array($this->energy, $validEnergyValues, true)) {
+        if (! in_array($this->energy, ModuleEnergy::ENERGY_LEVELS, true)) {
             throw ValidationException::withMessages([
                 'energy' => 'Invalid energy value.',
             ]);

--- a/app/Actions/LogHealth.php
+++ b/app/Actions/LogHealth.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleHealth;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -39,8 +40,7 @@ final readonly class LogHealth
             throw new ModelNotFoundException('Journal entry not found');
         }
 
-        $validHealthValues = ['good', 'okay', 'not great'];
-        if (!in_array($this->health, $validHealthValues)) {
+        if (! in_array($this->health, ModuleHealth::HEALTH_VALUES, true)) {
             throw ValidationException::withMessages([
                 'health' => 'Invalid health value.',
             ]);

--- a/app/Actions/LogHygiene.php
+++ b/app/Actions/LogHygiene.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleHygiene;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -53,7 +54,7 @@ final readonly class LogHygiene
             ]);
         }
 
-        if ($this->brushedTeeth !== null && ! in_array($this->brushedTeeth, ['no', 'am', 'pm'], true)) {
+        if ($this->brushedTeeth !== null && ! in_array($this->brushedTeeth, ModuleHygiene::BRUSHED_TEETH_VALUES, true)) {
             throw ValidationException::withMessages([
                 'brushed_teeth' => 'Invalid brushed teeth value.',
             ]);

--- a/app/Actions/LogMood.php
+++ b/app/Actions/LogMood.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleMood;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -39,8 +40,7 @@ final readonly class LogMood
             throw new ModelNotFoundException('Journal entry not found');
         }
 
-        $validMoodValues = ['terrible', 'bad', 'okay', 'good', 'great'];
-        if (! in_array($this->mood, $validMoodValues, true)) {
+        if (! in_array($this->mood, ModuleMood::MOOD_VALUES, true)) {
             throw ValidationException::withMessages([
                 'mood' => 'Invalid mood value.',
             ]);

--- a/app/Actions/LogPhysicalActivity.php
+++ b/app/Actions/LogPhysicalActivity.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModulePhysicalActivity;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -47,13 +48,13 @@ final readonly class LogPhysicalActivity
             ]);
         }
 
-        if ($this->activityType !== null && ! in_array($this->activityType, ['running', 'cycling', 'swimming', 'gym', 'walking'], true)) {
+        if ($this->activityType !== null && ! in_array($this->activityType, ModulePhysicalActivity::ACTIVITY_TYPES, true)) {
             throw ValidationException::withMessages([
                 'activity_type' => 'Invalid activity type value.',
             ]);
         }
 
-        if ($this->activityIntensity !== null && ! in_array($this->activityIntensity, ['light', 'moderate', 'intense'], true)) {
+        if ($this->activityIntensity !== null && ! in_array($this->activityIntensity, ModulePhysicalActivity::ACTIVITY_INTENSITIES, true)) {
             throw ValidationException::withMessages([
                 'activity_intensity' => 'Invalid activity intensity value.',
             ]);

--- a/app/Actions/LogPrimaryObligation.php
+++ b/app/Actions/LogPrimaryObligation.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModulePrimaryObligation;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -39,8 +40,7 @@ final readonly class LogPrimaryObligation
             throw new ModelNotFoundException('Journal entry not found');
         }
 
-        $validObligationValues = ['work', 'family', 'personal', 'health', 'travel', 'none'];
-        if (! in_array($this->primaryObligation, $validObligationValues, true)) {
+        if (! in_array($this->primaryObligation, ModulePrimaryObligation::PRIMARY_OBLIGATIONS, true)) {
             throw ValidationException::withMessages([
                 'primary_obligation' => 'Invalid primary obligation value.',
             ]);

--- a/app/Actions/LogSexualActivity.php
+++ b/app/Actions/LogSexualActivity.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleSexualActivity;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -52,7 +53,7 @@ final readonly class LogSexualActivity
             ]);
         }
 
-        if ($this->sexualActivityType !== null && ! in_array($this->sexualActivityType, ['solo', 'with-partner', 'intimate-contact'], true)) {
+        if ($this->sexualActivityType !== null && ! in_array($this->sexualActivityType, ModuleSexualActivity::SEXUAL_ACTIVITY_TYPES, true)) {
             throw ValidationException::withMessages([
                 'sexual_activity_type' => 'Invalid sexual activity type value.',
             ]);

--- a/app/Actions/LogShopping.php
+++ b/app/Actions/LogShopping.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleShopping;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -67,19 +68,8 @@ final readonly class LogShopping
                 ]);
             }
 
-            $validTypes = [
-                'groceries',
-                'clothes',
-                'electronics_tech',
-                'household_essentials',
-                'books_media',
-                'gifts',
-                'online_shopping',
-                'other',
-            ];
-
             foreach ($this->shoppingTypes as $type) {
-                if (! is_string($type) || ! in_array($type, $validTypes, true)) {
+                if (! is_string($type) || ! in_array($type, ModuleShopping::SHOPPING_TYPES, true)) {
                     throw ValidationException::withMessages([
                         'shopping_types' => 'Invalid shopping type value.',
                     ]);
@@ -87,19 +77,19 @@ final readonly class LogShopping
             }
         }
 
-        if ($this->shoppingIntent !== null && ! in_array($this->shoppingIntent, ['planned', 'opportunistic', 'impulse', 'replacement'], true)) {
+        if ($this->shoppingIntent !== null && ! in_array($this->shoppingIntent, ModuleShopping::SHOPPING_INTENTS, true)) {
             throw ValidationException::withMessages([
                 'shopping_intent' => 'Invalid shopping intent value.',
             ]);
         }
 
-        if ($this->shoppingContext !== null && ! in_array($this->shoppingContext, ['alone', 'with_partner', 'with_kids'], true)) {
+        if ($this->shoppingContext !== null && ! in_array($this->shoppingContext, ModuleShopping::SHOPPING_CONTEXTS, true)) {
             throw ValidationException::withMessages([
                 'shopping_context' => 'Invalid shopping context value.',
             ]);
         }
 
-        if ($this->shoppingFor !== null && ! in_array($this->shoppingFor, ['for_self', 'for_household', 'for_others'], true)) {
+        if ($this->shoppingFor !== null && ! in_array($this->shoppingFor, ModuleShopping::SHOPPING_FOR_OPTIONS, true)) {
             throw ValidationException::withMessages([
                 'shopping_for' => 'Invalid shopping for value.',
             ]);

--- a/app/Actions/LogSocialDensity.php
+++ b/app/Actions/LogSocialDensity.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleSocialDensity;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -39,8 +40,7 @@ final readonly class LogSocialDensity
             throw new ModelNotFoundException('Journal entry not found');
         }
 
-        $validSocialDensityValues = ['alone', 'few people', 'crowd', 'too much'];
-        if (! in_array($this->socialDensity, $validSocialDensityValues, true)) {
+        if (! in_array($this->socialDensity, ModuleSocialDensity::SOCIAL_DENSITY_VALUES, true)) {
             throw ValidationException::withMessages([
                 'social_density' => 'Invalid social density value.',
             ]);

--- a/app/Actions/LogTravel.php
+++ b/app/Actions/LogTravel.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleTravel;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -59,10 +60,8 @@ final readonly class LogTravel
                 ]);
             }
 
-            $validModes = ['car', 'plane', 'train', 'bike', 'bus', 'walk', 'boat', 'other'];
-
             foreach ($this->travelModes as $mode) {
-                if (! is_string($mode) || ! in_array($mode, $validModes, true)) {
+                if (! is_string($mode) || ! in_array($mode, ModuleTravel::TRAVEL_MODES, true)) {
                     throw ValidationException::withMessages([
                         'travel_modes' => 'Invalid travel mode value.',
                     ]);

--- a/app/Actions/LogTypeOfDay.php
+++ b/app/Actions/LogTypeOfDay.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleDayType;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use InvalidArgumentException;
@@ -42,8 +43,10 @@ final readonly class LogTypeOfDay
             throw new ModelNotFoundException('Journal not found');
         }
 
-        if (! in_array($this->dayType, ['workday', 'day off', 'weekend', 'vacation', 'sick day'])) {
-            throw new InvalidArgumentException('dayType must be one of: "workday", "day off", "weekend", "vacation", "sick day"');
+        if (! in_array($this->dayType, ModuleDayType::DAY_TYPES, true)) {
+            $dayTypes = implode('", "', ModuleDayType::DAY_TYPES);
+
+            throw new InvalidArgumentException('dayType must be one of: "' . $dayTypes . '"');
         }
     }
 

--- a/app/Actions/LogWork.php
+++ b/app/Actions/LogWork.php
@@ -8,6 +8,7 @@ use App\Jobs\CheckPresenceOfContentInJournalEntry;
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
+use App\Models\ModuleWork;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
@@ -58,13 +59,13 @@ final readonly class LogWork
             ]);
         }
 
-        if ($this->workMode !== null && ! in_array($this->workMode, ['on-site', 'remote', 'hybrid'], true)) {
+        if ($this->workMode !== null && ! in_array($this->workMode, ModuleWork::WORK_MODES, true)) {
             throw ValidationException::withMessages([
                 'work_mode' => 'Invalid work mode value.',
             ]);
         }
 
-        if ($this->workLoad !== null && ! in_array($this->workLoad, ['light', 'medium', 'heavy'], true)) {
+        if ($this->workLoad !== null && ! in_array($this->workLoad, ModuleWork::WORK_LOADS, true)) {
             throw ValidationException::withMessages([
                 'work_load' => 'Invalid work load value.',
             ]);

--- a/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/DayType/DayTypeController.php
@@ -8,9 +8,11 @@ use App\Actions\LogTypeOfDay;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleDayType;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class DayTypeController extends Controller
 {
@@ -18,7 +20,7 @@ final class DayTypeController extends Controller
     {
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
-            'day_type' => ['required', 'string', 'max:255', 'in:workday,day off,weekend,vacation,sick day'],
+            'day_type' => ['required', 'string', 'max:255', Rule::in(ModuleDayType::DAY_TYPES)],
         ]);
 
         $entry = new LogTypeOfDay(

--- a/app/Http/Controllers/Api/Journals/Modules/Energy/EnergyController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Energy/EnergyController.php
@@ -8,9 +8,11 @@ use App\Actions\LogEnergy;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleEnergy;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class EnergyController extends Controller
 {
@@ -19,7 +21,7 @@ final class EnergyController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'energy' => ['required', 'string', 'max:255', 'in:very low,low,normal,high,very high'],
+            'energy' => ['required', 'string', 'max:255', Rule::in(ModuleEnergy::ENERGY_LEVELS)],
         ]);
 
         $entry = new LogEnergy(

--- a/app/Http/Controllers/Api/Journals/Modules/Health/HealthController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Health/HealthController.php
@@ -8,9 +8,11 @@ use App\Actions\LogHealth;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleHealth;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class HealthController extends Controller
 {
@@ -19,7 +21,7 @@ final class HealthController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'health' => ['required', 'string', 'max:255', 'in:good,okay,not great'],
+            'health' => ['required', 'string', 'max:255', Rule::in(ModuleHealth::HEALTH_VALUES)],
         ]);
 
         $entry = new LogHealth(

--- a/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Hygiene/HygieneController.php
@@ -8,9 +8,11 @@ use App\Actions\LogHygiene;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleHygiene;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class HygieneController extends Controller
 {
@@ -20,7 +22,7 @@ final class HygieneController extends Controller
 
         $validated = $request->validate([
             'showered' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:brushed_teeth,skincare'],
-            'brushed_teeth' => ['nullable', 'string', 'max:255', 'in:no,am,pm', 'required_without_all:showered,skincare'],
+            'brushed_teeth' => ['nullable', 'string', 'max:255', Rule::in(ModuleHygiene::BRUSHED_TEETH_VALUES), 'required_without_all:showered,skincare'],
             'skincare' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:showered,brushed_teeth'],
         ]);
 

--- a/app/Http/Controllers/Api/Journals/Modules/Mood/MoodController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Mood/MoodController.php
@@ -8,9 +8,11 @@ use App\Actions\LogMood;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleMood;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class MoodController extends Controller
 {
@@ -19,7 +21,7 @@ final class MoodController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'mood' => ['required', 'string', 'max:255', 'in:terrible,bad,okay,good,great'],
+            'mood' => ['required', 'string', 'max:255', Rule::in(ModuleMood::MOOD_VALUES)],
         ]);
 
         $entry = new LogMood(

--- a/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
@@ -8,9 +8,11 @@ use App\Actions\LogPhysicalActivity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModulePhysicalActivity;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class PhysicalActivityController extends Controller
 {
@@ -20,8 +22,8 @@ final class PhysicalActivityController extends Controller
 
         $validated = $request->validate([
             'has_done_physical_activity' => ['nullable', 'string', 'max:255', 'in:yes,no'],
-            'activity_type' => ['nullable', 'string', 'max:255', 'in:running,cycling,swimming,gym,walking'],
-            'activity_intensity' => ['nullable', 'string', 'max:255', 'in:light,moderate,intense'],
+            'activity_type' => ['nullable', 'string', 'max:255', Rule::in(ModulePhysicalActivity::ACTIVITY_TYPES)],
+            'activity_intensity' => ['nullable', 'string', 'max:255', Rule::in(ModulePhysicalActivity::ACTIVITY_INTENSITIES)],
         ]);
 
         $entry = new LogPhysicalActivity(

--- a/app/Http/Controllers/Api/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
@@ -8,9 +8,11 @@ use App\Actions\LogPrimaryObligation;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModulePrimaryObligation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class PrimaryObligationController extends Controller
 {
@@ -19,7 +21,7 @@ final class PrimaryObligationController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'primary_obligation' => ['required', 'string', 'max:255', 'in:work,family,personal,health,travel,none'],
+            'primary_obligation' => ['required', 'string', 'max:255', Rule::in(ModulePrimaryObligation::PRIMARY_OBLIGATIONS)],
         ]);
 
         $entry = new LogPrimaryObligation(

--- a/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/SexualActivity/SexualActivityController.php
@@ -8,9 +8,11 @@ use App\Actions\LogSexualActivity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleSexualActivity;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class SexualActivityController extends Controller
 {
@@ -19,7 +21,7 @@ final class SexualActivityController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
             'had_sexual_activity' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:sexual_activity_type'],
-            'sexual_activity_type' => ['nullable', 'string', 'max:255', 'in:solo,with-partner,intimate-contact', 'required_without_all:had_sexual_activity'],
+            'sexual_activity_type' => ['nullable', 'string', 'max:255', Rule::in(ModuleSexualActivity::SEXUAL_ACTIVITY_TYPES), 'required_without_all:had_sexual_activity'],
         ]);
 
         $entry = new LogSexualActivity(

--- a/app/Http/Controllers/Api/Journals/Modules/Shopping/ShoppingController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Shopping/ShoppingController.php
@@ -8,9 +8,11 @@ use App\Actions\LogShopping;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleShopping;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class ShoppingController extends Controller
 {
@@ -24,11 +26,11 @@ final class ShoppingController extends Controller
             'shopping_types.*' => [
                 'string',
                 'max:255',
-                'in:groceries,clothes,electronics_tech,household_essentials,books_media,gifts,online_shopping,other',
+                Rule::in(ModuleShopping::SHOPPING_TYPES),
             ],
-            'shopping_intent' => ['nullable', 'string', 'max:255', 'in:planned,opportunistic,impulse,replacement', 'required_without_all:has_shopped,shopping_types,shopping_context,shopping_for'],
-            'shopping_context' => ['nullable', 'string', 'max:255', 'in:alone,with_partner,with_kids', 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_for'],
-            'shopping_for' => ['nullable', 'string', 'max:255', 'in:for_self,for_household,for_others', 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_context'],
+            'shopping_intent' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_INTENTS), 'required_without_all:has_shopped,shopping_types,shopping_context,shopping_for'],
+            'shopping_context' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_CONTEXTS), 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_for'],
+            'shopping_for' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_FOR_OPTIONS), 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_context'],
         ]);
 
         $entry = new LogShopping(

--- a/app/Http/Controllers/Api/Journals/Modules/SocialDensity/SocialDensityController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/SocialDensity/SocialDensityController.php
@@ -8,9 +8,11 @@ use App\Actions\LogSocialDensity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleSocialDensity;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class SocialDensityController extends Controller
 {
@@ -19,7 +21,7 @@ final class SocialDensityController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'social_density' => ['required', 'string', 'max:255', 'in:alone,few people,crowd,too much'],
+            'social_density' => ['required', 'string', 'max:255', Rule::in(ModuleSocialDensity::SOCIAL_DENSITY_VALUES)],
         ]);
 
         $entry = new LogSocialDensity(

--- a/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Travel/TravelController.php
@@ -8,9 +8,11 @@ use App\Actions\LogTravel;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleTravel;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class TravelController extends Controller
 {
@@ -23,7 +25,7 @@ final class TravelController extends Controller
             'travel_modes.*' => [
                 'string',
                 'max:255',
-                'in:car,plane,train,bike,bus,walk,boat,other',
+                Rule::in(ModuleTravel::TRAVEL_MODES),
             ],
         ]);
 

--- a/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Work/WorkController.php
@@ -8,9 +8,11 @@ use App\Actions\LogWork;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleWork;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class WorkController extends Controller
 {
@@ -19,8 +21,8 @@ final class WorkController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
         $validated = $request->validate([
             'worked' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:work_mode,work_load,work_procrastinated'],
-            'work_mode' => ['nullable', 'string', 'max:255', 'in:on-site,remote,hybrid', 'required_without_all:worked,work_load,work_procrastinated'],
-            'work_load' => ['nullable', 'string', 'max:255', 'in:light,medium,heavy', 'required_without_all:worked,work_mode,work_procrastinated'],
+            'work_mode' => ['nullable', 'string', 'max:255', Rule::in(ModuleWork::WORK_MODES), 'required_without_all:worked,work_load,work_procrastinated'],
+            'work_load' => ['nullable', 'string', 'max:255', Rule::in(ModuleWork::WORK_LOADS), 'required_without_all:worked,work_mode,work_procrastinated'],
             'work_procrastinated' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:worked,work_mode,work_load'],
         ]);
 

--- a/app/Http/Controllers/App/Journals/Modules/DayType/DayTypeController.php
+++ b/app/Http/Controllers/App/Journals/Modules/DayType/DayTypeController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\App\Journals\Modules\DayType;
 use App\Actions\LogTypeOfDay;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleDayType;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class DayTypeController extends Controller
 {
@@ -18,7 +20,7 @@ final class DayTypeController extends Controller
         $journalEntry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'day_type' => ['required', 'string', 'max:255', 'in:workday,day off,weekend,vacation,sick day'],
+            'day_type' => ['required', 'string', 'max:255', Rule::in(ModuleDayType::DAY_TYPES)],
         ]);
 
         new LogTypeOfDay(

--- a/app/Http/Controllers/App/Journals/Modules/Energy/EnergyController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Energy/EnergyController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\Energy;
 use App\Actions\LogEnergy;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleEnergy;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class EnergyController extends Controller
@@ -18,7 +20,7 @@ final class EnergyController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'energy' => ['required', 'string', 'max:255', 'in:very low,low,normal,high,very high'],
+            'energy' => ['required', 'string', 'max:255', Rule::in(ModuleEnergy::ENERGY_LEVELS)],
         ]);
 
         new LogEnergy(

--- a/app/Http/Controllers/App/Journals/Modules/Health/HealthController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Health/HealthController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\Health;
 use App\Actions\LogHealth;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleHealth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class HealthController extends Controller
@@ -18,7 +20,7 @@ final class HealthController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'health' => ['required', 'string', 'max:255', 'in:good,okay,not great'],
+            'health' => ['required', 'string', 'max:255', Rule::in(ModuleHealth::HEALTH_VALUES)],
         ]);
 
         new LogHealth(

--- a/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Hygiene/HygieneController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\Hygiene;
 use App\Actions\LogHygiene;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleHygiene;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class HygieneController extends Controller
@@ -19,7 +21,7 @@ final class HygieneController extends Controller
 
         $validated = $request->validate([
             'showered' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:brushed_teeth,skincare'],
-            'brushed_teeth' => ['nullable', 'string', 'max:255', 'in:no,am,pm', 'required_without_all:showered,skincare'],
+            'brushed_teeth' => ['nullable', 'string', 'max:255', Rule::in(ModuleHygiene::BRUSHED_TEETH_VALUES), 'required_without_all:showered,skincare'],
             'skincare' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:showered,brushed_teeth'],
         ]);
 

--- a/app/Http/Controllers/App/Journals/Modules/Mood/MoodController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Mood/MoodController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\Mood;
 use App\Actions\LogMood;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleMood;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class MoodController extends Controller
@@ -18,7 +20,7 @@ final class MoodController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'mood' => ['required', 'string', 'max:255', 'in:terrible,bad,okay,good,great'],
+            'mood' => ['required', 'string', 'max:255', Rule::in(ModuleMood::MOOD_VALUES)],
         ]);
 
         new LogMood(

--- a/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PhysicalActivity/PhysicalActivityController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\PhysicalActivity;
 use App\Actions\LogPhysicalActivity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModulePhysicalActivity;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class PhysicalActivityController extends Controller
@@ -19,8 +21,8 @@ final class PhysicalActivityController extends Controller
 
         $validated = $request->validate([
             'has_done_physical_activity' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:activity_type,activity_intensity'],
-            'activity_type' => ['nullable', 'string', 'max:255', 'in:running,cycling,swimming,gym,walking', 'required_without_all:has_done_physical_activity,activity_intensity'],
-            'activity_intensity' => ['nullable', 'string', 'max:255', 'in:light,moderate,intense', 'required_without_all:has_done_physical_activity,activity_type'],
+            'activity_type' => ['nullable', 'string', 'max:255', Rule::in(ModulePhysicalActivity::ACTIVITY_TYPES), 'required_without_all:has_done_physical_activity,activity_intensity'],
+            'activity_intensity' => ['nullable', 'string', 'max:255', Rule::in(ModulePhysicalActivity::ACTIVITY_INTENSITIES), 'required_without_all:has_done_physical_activity,activity_type'],
         ]);
 
         new LogPhysicalActivity(

--- a/app/Http/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
+++ b/app/Http/Controllers/App/Journals/Modules/PrimaryObligation/PrimaryObligationController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\PrimaryObligation;
 use App\Actions\LogPrimaryObligation;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModulePrimaryObligation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class PrimaryObligationController extends Controller
@@ -18,7 +20,7 @@ final class PrimaryObligationController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'primary_obligation' => ['required', 'string', 'max:255', 'in:work,family,personal,health,travel,none'],
+            'primary_obligation' => ['required', 'string', 'max:255', Rule::in(ModulePrimaryObligation::PRIMARY_OBLIGATIONS)],
         ]);
 
         new LogPrimaryObligation(

--- a/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/SexualActivity/SexualActivityController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\App\Journals\Modules\SexualActivity;
 use App\Actions\LogSexualActivity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleSexualActivity;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class SexualActivityController extends Controller
 {
@@ -19,7 +21,7 @@ final class SexualActivityController extends Controller
 
         $validated = $request->validate([
             'had_sexual_activity' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:sexual_activity_type'],
-            'sexual_activity_type' => ['nullable', 'string', 'max:255', 'in:solo,with-partner,intimate-contact', 'required_without_all:had_sexual_activity'],
+            'sexual_activity_type' => ['nullable', 'string', 'max:255', Rule::in(ModuleSexualActivity::SEXUAL_ACTIVITY_TYPES), 'required_without_all:had_sexual_activity'],
         ]);
 
         new LogSexualActivity(

--- a/app/Http/Controllers/App/Journals/Modules/Shopping/ShoppingController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Shopping/ShoppingController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\App\Journals\Modules\Shopping;
 use App\Actions\LogShopping;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleShopping;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class ShoppingController extends Controller
 {
@@ -23,11 +25,11 @@ final class ShoppingController extends Controller
             'shopping_types.*' => [
                 'string',
                 'max:255',
-                'in:groceries,clothes,electronics_tech,household_essentials,books_media,gifts,online_shopping,other',
+                Rule::in(ModuleShopping::SHOPPING_TYPES),
             ],
-            'shopping_intent' => ['nullable', 'string', 'max:255', 'in:planned,opportunistic,impulse,replacement', 'required_without_all:has_shopped,shopping_types,shopping_context,shopping_for'],
-            'shopping_context' => ['nullable', 'string', 'max:255', 'in:alone,with_partner,with_kids', 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_for'],
-            'shopping_for' => ['nullable', 'string', 'max:255', 'in:for_self,for_household,for_others', 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_context'],
+            'shopping_intent' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_INTENTS), 'required_without_all:has_shopped,shopping_types,shopping_context,shopping_for'],
+            'shopping_context' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_CONTEXTS), 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_for'],
+            'shopping_for' => ['nullable', 'string', 'max:255', Rule::in(ModuleShopping::SHOPPING_FOR_OPTIONS), 'required_without_all:has_shopped,shopping_types,shopping_intent,shopping_context'],
         ]);
 
         new LogShopping(

--- a/app/Http/Controllers/App/Journals/Modules/SocialDensity/SocialDensityController.php
+++ b/app/Http/Controllers/App/Journals/Modules/SocialDensity/SocialDensityController.php
@@ -7,8 +7,10 @@ namespace App\Http\Controllers\App\Journals\Modules\SocialDensity;
 use App\Actions\LogSocialDensity;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleSocialDensity;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 final class SocialDensityController extends Controller
@@ -18,7 +20,7 @@ final class SocialDensityController extends Controller
         $entry = $request->attributes->get('journal_entry');
 
         $validated = $request->validate([
-            'social_density' => ['required', 'string', 'max:255', 'in:alone,few people,crowd,too much'],
+            'social_density' => ['required', 'string', 'max:255', Rule::in(ModuleSocialDensity::SOCIAL_DENSITY_VALUES)],
         ]);
 
         new LogSocialDensity(

--- a/app/Http/Controllers/App/Journals/Modules/Travel/TravelController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Travel/TravelController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\App\Journals\Modules\Travel;
 use App\Actions\LogTravel;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleTravel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class TravelController extends Controller
 {
@@ -23,7 +25,7 @@ final class TravelController extends Controller
             'travel_modes.*' => [
                 'string',
                 'max:255',
-                'in:car,plane,train,bike,bus,walk,boat,other',
+                Rule::in(ModuleTravel::TRAVEL_MODES),
             ],
         ]);
 

--- a/app/Http/Controllers/App/Journals/Modules/Work/WorkController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Work/WorkController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\App\Journals\Modules\Work;
 use App\Actions\LogWork;
 use App\Helpers\TextSanitizer;
 use App\Http\Controllers\Controller;
+use App\Models\ModuleWork;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 final class WorkController extends Controller
 {
@@ -19,8 +21,8 @@ final class WorkController extends Controller
 
         $validated = $request->validate([
             'worked' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:work_mode,work_load,work_procrastinated'],
-            'work_mode' => ['nullable', 'string', 'max:255', 'in:on-site,remote,hybrid', 'required_without_all:worked,work_load,work_procrastinated'],
-            'work_load' => ['nullable', 'string', 'max:255', 'in:light,medium,heavy', 'required_without_all:worked,work_mode,work_procrastinated'],
+            'work_mode' => ['nullable', 'string', 'max:255', Rule::in(ModuleWork::WORK_MODES), 'required_without_all:worked,work_load,work_procrastinated'],
+            'work_load' => ['nullable', 'string', 'max:255', Rule::in(ModuleWork::WORK_LOADS), 'required_without_all:worked,work_mode,work_procrastinated'],
             'work_procrastinated' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:worked,work_mode,work_load'],
         ]);
 

--- a/app/Models/ModuleDayType.php
+++ b/app/Models/ModuleDayType.php
@@ -26,6 +26,14 @@ final class ModuleDayType extends Model
     /** @use HasFactory<\Database\Factories\ModuleDayTypeFactory> */
     use HasFactory;
 
+    public const array DAY_TYPES = [
+        'workday',
+        'day off',
+        'weekend',
+        'vacation',
+        'sick day',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleEnergy.php
+++ b/app/Models/ModuleEnergy.php
@@ -26,6 +26,14 @@ final class ModuleEnergy extends Model
     /** @use HasFactory<\Database\Factories\ModuleEnergyFactory> */
     use HasFactory;
 
+    public const array ENERGY_LEVELS = [
+        'very low',
+        'low',
+        'normal',
+        'high',
+        'very high',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleHealth.php
+++ b/app/Models/ModuleHealth.php
@@ -26,6 +26,12 @@ final class ModuleHealth extends Model
     /** @use HasFactory<\Database\Factories\ModuleHealthFactory> */
     use HasFactory;
 
+    public const array HEALTH_VALUES = [
+        'not great',
+        'okay',
+        'good',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleHygiene.php
+++ b/app/Models/ModuleHygiene.php
@@ -28,6 +28,12 @@ final class ModuleHygiene extends Model
     /** @use HasFactory<\Database\Factories\ModuleHygieneFactory> */
     use HasFactory;
 
+    public const array BRUSHED_TEETH_VALUES = [
+        'no',
+        'am',
+        'pm',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleMood.php
+++ b/app/Models/ModuleMood.php
@@ -26,6 +26,14 @@ final class ModuleMood extends Model
     /** @use HasFactory<\Database\Factories\ModuleMoodFactory> */
     use HasFactory;
 
+    public const array MOOD_VALUES = [
+        'terrible',
+        'bad',
+        'okay',
+        'good',
+        'great',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModulePhysicalActivity.php
+++ b/app/Models/ModulePhysicalActivity.php
@@ -28,6 +28,20 @@ final class ModulePhysicalActivity extends Model
     /** @use HasFactory<\Database\Factories\ModulePhysicalActivityFactory> */
     use HasFactory;
 
+    public const array ACTIVITY_TYPES = [
+        'running',
+        'cycling',
+        'swimming',
+        'gym',
+        'walking',
+    ];
+
+    public const array ACTIVITY_INTENSITIES = [
+        'light',
+        'moderate',
+        'intense',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModulePrimaryObligation.php
+++ b/app/Models/ModulePrimaryObligation.php
@@ -26,6 +26,15 @@ final class ModulePrimaryObligation extends Model
     /** @use HasFactory<\Database\Factories\ModulePrimaryObligationFactory> */
     use HasFactory;
 
+    public const array PRIMARY_OBLIGATIONS = [
+        'work',
+        'family',
+        'personal',
+        'health',
+        'travel',
+        'none',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleSexualActivity.php
+++ b/app/Models/ModuleSexualActivity.php
@@ -27,6 +27,12 @@ final class ModuleSexualActivity extends Model
     /** @use HasFactory<\Database\Factories\ModuleSexualActivityFactory> */
     use HasFactory;
 
+    public const array SEXUAL_ACTIVITY_TYPES = [
+        'solo',
+        'with-partner',
+        'intimate-contact',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleShopping.php
+++ b/app/Models/ModuleShopping.php
@@ -30,6 +30,36 @@ final class ModuleShopping extends Model
     /** @use HasFactory<\Database\Factories\ModuleShoppingFactory> */
     use HasFactory;
 
+    public const array SHOPPING_TYPES = [
+        'groceries',
+        'clothes',
+        'electronics_tech',
+        'household_essentials',
+        'books_media',
+        'gifts',
+        'online_shopping',
+        'other',
+    ];
+
+    public const array SHOPPING_INTENTS = [
+        'planned',
+        'opportunistic',
+        'impulse',
+        'replacement',
+    ];
+
+    public const array SHOPPING_CONTEXTS = [
+        'alone',
+        'with_partner',
+        'with_kids',
+    ];
+
+    public const array SHOPPING_FOR_OPTIONS = [
+        'for_self',
+        'for_household',
+        'for_others',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleSocialDensity.php
+++ b/app/Models/ModuleSocialDensity.php
@@ -26,6 +26,13 @@ final class ModuleSocialDensity extends Model
     /** @use HasFactory<\Database\Factories\ModuleSocialDensityFactory> */
     use HasFactory;
 
+    public const array SOCIAL_DENSITY_VALUES = [
+        'alone',
+        'few people',
+        'crowd',
+        'too much',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleTravel.php
+++ b/app/Models/ModuleTravel.php
@@ -28,6 +28,17 @@ final class ModuleTravel extends Model
     /** @use HasFactory<\Database\Factories\ModuleTravelFactory> */
     use HasFactory;
 
+    public const array TRAVEL_MODES = [
+        'car',
+        'plane',
+        'train',
+        'bike',
+        'bus',
+        'walk',
+        'boat',
+        'other',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/ModuleWork.php
+++ b/app/Models/ModuleWork.php
@@ -29,6 +29,18 @@ final class ModuleWork extends Model
     /** @use HasFactory<\Database\Factories\ModuleWorkFactory> */
     use HasFactory;
 
+    public const array WORK_MODES = [
+        'remote',
+        'on-site',
+        'hybrid',
+    ];
+
+    public const array WORK_LOADS = [
+        'light',
+        'medium',
+        'heavy',
+    ];
+
     /**
      * The table associated with the model.
      *

--- a/app/View/Presenters/DayTypeModulePresenter.php
+++ b/app/View/Presenters/DayTypeModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleDayType;
 
 final readonly class DayTypeModulePresenter
 {
@@ -30,7 +31,7 @@ final readonly class DayTypeModulePresenter
             'day' => $this->entry->day,
         ]);
 
-        $dayTypes = collect(['workday', 'day off', 'weekend', 'vacation', 'sick day'])->map(fn($type) => [
+        $dayTypes = collect(ModuleDayType::DAY_TYPES)->map(fn($type) => [
             'value' => $type,
             'label' => match ($type) {
                 'workday' => __('Workday'),

--- a/app/View/Presenters/EnergyModulePresenter.php
+++ b/app/View/Presenters/EnergyModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleEnergy;
 
 final readonly class EnergyModulePresenter
 {
@@ -38,7 +39,7 @@ final readonly class EnergyModulePresenter
     {
         $energy = $this->entry->moduleEnergy?->energy;
 
-        return collect(['very low', 'low', 'normal', 'high', 'very high'])->map(fn($value) => [
+        return collect(ModuleEnergy::ENERGY_LEVELS)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'very low' => __('Very low'),

--- a/app/View/Presenters/HealthModulePresenter.php
+++ b/app/View/Presenters/HealthModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleHealth;
 
 final readonly class HealthModulePresenter
 {
@@ -38,7 +39,7 @@ final readonly class HealthModulePresenter
     {
         $health = $this->entry->moduleHealth?->health;
 
-        return collect(['not great', 'okay', 'good'])->map(fn($value) => [
+        return collect(ModuleHealth::HEALTH_VALUES)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'not great' => __('Not great'),

--- a/app/View/Presenters/MoodModulePresenter.php
+++ b/app/View/Presenters/MoodModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleMood;
 
 final readonly class MoodModulePresenter
 {
@@ -34,7 +35,7 @@ final readonly class MoodModulePresenter
 
     private function moodOptions(): array
     {
-        return collect(['terrible', 'bad', 'okay', 'good', 'great'])->map(fn($value) => [
+        return collect(ModuleMood::MOOD_VALUES)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'terrible' => __('Terrible'),

--- a/app/View/Presenters/PhysicalActivityModulePresenter.php
+++ b/app/View/Presenters/PhysicalActivityModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModulePhysicalActivity;
 
 final readonly class PhysicalActivityModulePresenter
 {
@@ -40,7 +41,7 @@ final readonly class PhysicalActivityModulePresenter
 
     private function activityTypes(?string $selectedType): array
     {
-        return collect(['running', 'cycling', 'swimming', 'gym', 'walking'])->map(fn($value) => [
+        return collect(ModulePhysicalActivity::ACTIVITY_TYPES)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'running' => __('Running'),
@@ -56,7 +57,7 @@ final readonly class PhysicalActivityModulePresenter
 
     private function activityIntensities(?string $selectedIntensity): array
     {
-        return collect(['light', 'moderate', 'intense'])->map(fn($value) => [
+        return collect(ModulePhysicalActivity::ACTIVITY_INTENSITIES)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'light' => __('Light'),

--- a/app/View/Presenters/PrimaryObligationModulePresenter.php
+++ b/app/View/Presenters/PrimaryObligationModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModulePrimaryObligation;
 
 final readonly class PrimaryObligationModulePresenter
 {
@@ -38,7 +39,7 @@ final readonly class PrimaryObligationModulePresenter
     {
         $modulePrimaryObligation = $this->entry->modulePrimaryObligation;
 
-        return collect(['work', 'family', 'personal', 'health', 'travel', 'none'])->map(fn($value) => [
+        return collect(ModulePrimaryObligation::PRIMARY_OBLIGATIONS)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'work' => __('Work'),

--- a/app/View/Presenters/SexualActivityModulePresenter.php
+++ b/app/View/Presenters/SexualActivityModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleSexualActivity;
 
 final readonly class SexualActivityModulePresenter
 {
@@ -28,7 +29,7 @@ final readonly class SexualActivityModulePresenter
             'day' => $this->entry->day,
         ]);
 
-        $activityTypes = collect(['solo', 'with-partner', 'intimate-contact'])->map(fn($type) => [
+        $activityTypes = collect(ModuleSexualActivity::SEXUAL_ACTIVITY_TYPES)->map(fn($type) => [
             'value' => $type,
             'label' => match ($type) {
                 'solo' => __('Solo'),

--- a/app/View/Presenters/ShoppingModulePresenter.php
+++ b/app/View/Presenters/ShoppingModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleShopping;
 
 final readonly class ShoppingModulePresenter
 {
@@ -46,16 +47,7 @@ final readonly class ShoppingModulePresenter
     {
         $selectedTypes = $this->entry->moduleShopping?->shopping_type;
 
-        return collect([
-            'groceries',
-            'clothes',
-            'electronics_tech',
-            'household_essentials',
-            'books_media',
-            'gifts',
-            'online_shopping',
-            'other',
-        ])->map(fn(string $type) => [
+        return collect(ModuleShopping::SHOPPING_TYPES)->map(fn(string $type) => [
             'value' => $type,
             'label' => match ($type) {
                 'groceries' => __('Groceries'),
@@ -76,7 +68,7 @@ final readonly class ShoppingModulePresenter
     {
         $intent = $this->entry->moduleShopping?->shopping_intent;
 
-        return collect(['planned', 'opportunistic', 'impulse', 'replacement'])->map(fn(string $value) => [
+        return collect(ModuleShopping::SHOPPING_INTENTS)->map(fn(string $value) => [
             'value' => $value,
             'label' => match ($value) {
                 'planned' => __('Planned'),
@@ -93,7 +85,7 @@ final readonly class ShoppingModulePresenter
     {
         $context = $this->entry->moduleShopping?->shopping_context;
 
-        return collect(['alone', 'with_partner', 'with_kids'])->map(fn(string $value) => [
+        return collect(ModuleShopping::SHOPPING_CONTEXTS)->map(fn(string $value) => [
             'value' => $value,
             'label' => match ($value) {
                 'alone' => __('Alone'),
@@ -109,7 +101,7 @@ final readonly class ShoppingModulePresenter
     {
         $shoppingFor = $this->entry->moduleShopping?->shopping_for;
 
-        return collect(['for_self', 'for_household', 'for_others'])->map(fn(string $value) => [
+        return collect(ModuleShopping::SHOPPING_FOR_OPTIONS)->map(fn(string $value) => [
             'value' => $value,
             'label' => match ($value) {
                 'for_self' => __('For self'),

--- a/app/View/Presenters/SocialDensityModulePresenter.php
+++ b/app/View/Presenters/SocialDensityModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleSocialDensity;
 
 final readonly class SocialDensityModulePresenter
 {
@@ -38,7 +39,7 @@ final readonly class SocialDensityModulePresenter
     {
         $moduleSocialDensity = $this->entry->moduleSocialDensity;
 
-        return collect(['alone', 'few people', 'crowd', 'too much'])->map(fn($value) => [
+        return collect(ModuleSocialDensity::SOCIAL_DENSITY_VALUES)->map(fn($value) => [
             'value' => $value,
             'label' => match ($value) {
                 'alone' => __('Alone'),

--- a/app/View/Presenters/TravelModulePresenter.php
+++ b/app/View/Presenters/TravelModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleTravel;
 
 final readonly class TravelModulePresenter
 {
@@ -29,7 +30,7 @@ final readonly class TravelModulePresenter
             'day' => $this->entry->day,
         ]);
 
-        $travelModes = collect(['car', 'plane', 'train', 'bike', 'bus', 'walk', 'boat', 'other'])->map(fn($mode) => [
+        $travelModes = collect(ModuleTravel::TRAVEL_MODES)->map(fn($mode) => [
             'value' => $mode,
             'label' => match ($mode) {
                 'car' => __('Car'),

--- a/app/View/Presenters/WorkModulePresenter.php
+++ b/app/View/Presenters/WorkModulePresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\View\Presenters;
 
 use App\Models\JournalEntry;
+use App\Models\ModuleWork;
 
 final readonly class WorkModulePresenter
 {
@@ -30,7 +31,7 @@ final readonly class WorkModulePresenter
             'day' => $this->entry->day,
         ]);
 
-        $workModes = collect(['remote', 'on-site', 'hybrid'])->map(fn($mode) => [
+        $workModes = collect(ModuleWork::WORK_MODES)->map(fn($mode) => [
             'value' => $mode,
             'label' => match ($mode) {
                 'remote' => __('Remote'),
@@ -41,7 +42,7 @@ final readonly class WorkModulePresenter
             'is_selected' => $mode === $moduleWork?->work_mode,
         ]);
 
-        $workLoads = collect(['light', 'medium', 'heavy'])->map(fn($load) => [
+        $workLoads = collect(ModuleWork::WORK_LOADS)->map(fn($load) => [
             'value' => $load,
             'label' => match ($load) {
                 'light' => __('Light'),

--- a/tests/Unit/Presenters/DayTypeModulePresenterTest.php
+++ b/tests/Unit/Presenters/DayTypeModulePresenterTest.php
@@ -94,7 +94,7 @@ final class DayTypeModulePresenterTest extends TestCase
         $presenter = new DayTypeModulePresenter($entry);
         $result = $presenter->build();
 
-        $this->assertCount(5, $result['day_types']);
+        $this->assertCount(count(ModuleDayType::DAY_TYPES), $result['day_types']);
         $this->assertEquals(__('Workday'), $result['day_types'][0]['label']);
         $this->assertEquals(__('Day off'), $result['day_types'][1]['label']);
         $this->assertEquals(__('Weekend'), $result['day_types'][2]['label']);


### PR DESCRIPTION
### Motivation

- Replace scattered inline option arrays with a single source of truth to make validation and presenters resilient to future changes. 
- Reduce duplication across Actions, Controllers and Presenters by centralizing option lists on the models that own the data. 
- Make validation and UI option generation consistent and easier to maintain. 

### Description

- Added public `const` arrays with option values to the module models (examples: `ModuleMood::MOOD_VALUES`, `ModuleHealth::HEALTH_VALUES`, `ModuleEnergy::ENERGY_LEVELS`, `ModuleShopping::SHOPPING_TYPES`, `ModuleTravel::TRAVEL_MODES`, `ModuleWork::WORK_MODES` and others). 
- Updated Actions to validate against the new model constants (replacing inline `in_array(...)` lists). 
- Updated API and App Controllers to use `Illuminate\Validation\Rule::in(...)` with the model constants for request validation. 
- Updated Presenters to build option collections from the model constants and adjusted the DayType presenter test to assert against `ModuleDayType::DAY_TYPES`. 

### Testing

- Ran `vendor/bin/pint --dirty` to check formatting, but it failed due to missing `vendor/autoload.php` in the environment. 
- Ran `php artisan test tests/Unit/Presenters/DayTypeModulePresenterTest.php`, but it failed to run due to missing `vendor/autoload.php`. 
- Ran `composer journalos:unit` as the repo-wide verification, but it failed for the same `vendor/autoload.php` missing error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f9412e6083209fd720d8cd6ef6bb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Centralized module option constants**: Added public const arrays to 13 module models to serve as a single source of truth for validation values (ModuleMood, ModuleHealth, ModuleEnergy, ModuleShopping, ModuleTravel, ModuleWork, ModuleDayType, ModuleHygiene, ModulePhysicalActivity, ModulePrimaryObligation, ModuleSexualActivity, ModuleSocialDensity)

- **Updated validation in Actions**: All module Actions now validate against centralized model constants instead of inline arrays, improving maintainability and reducing duplication

- **Updated validation in Controllers**: Both API and App Controllers now use `Rule::in()` with model constants for request validation, replacing hard-coded validation rules

- **Updated Presenters**: All module Presenters now build option collections from model constants instead of inline arrays, ensuring UI options stay synchronized with validation rules

- **Test updates**: Updated DayTypeModulePresenterTest to assert against `ModuleDayType::DAY_TYPES` for dynamic test assertions

- **Benefits**: Reduces code duplication, ensures validation and UI option generation are consistent, and makes future changes to option values require updates in only one location per module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->