### PR TITLE
feat: prevent actions to edit entries if past

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,6 +9,7 @@
 - [ ] add an endpoint to let LLMs query the data\
 - [ ] add ability to indicate after how long we can't edit data from the past
 - [ ] add in every view, a comment at the top listing variables that are used (exmaple detials.balde.php)
+- [ ] cache to make things fast
 
 Life
 - [x] Sleep

--- a/app/Actions/LogBook.php
+++ b/app/Actions/LogBook.php
@@ -11,6 +11,8 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\Book;
 use App\Models\JournalEntry;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
 
@@ -19,6 +21,8 @@ use Illuminate\Support\Facades\DB;
  */
 final readonly class LogBook
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -44,6 +48,8 @@ final readonly class LogBook
         if ($this->book->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Book not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
     }
 
     private function log(): void

--- a/app/Actions/LogEnergy.php
+++ b/app/Actions/LogEnergy.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleEnergy;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogEnergy
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -39,6 +42,8 @@ final readonly class LogEnergy
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->energy, ModuleEnergy::ENERGY_LEVELS, true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogHadKidsToday.php
+++ b/app/Actions/LogHadKidsToday.php
@@ -9,6 +9,7 @@ use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use InvalidArgumentException;
 
@@ -17,6 +18,8 @@ use InvalidArgumentException;
  */
 final readonly class LogHadKidsToday
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -41,6 +44,8 @@ final readonly class LogHadKidsToday
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->hadKidsToday !== 'yes' && $this->hadKidsToday !== 'no') {
             throw new InvalidArgumentException('hadKidsToday must be either "yes" or "no"');

--- a/app/Actions/LogHealth.php
+++ b/app/Actions/LogHealth.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleHealth;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogHealth
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -39,6 +42,8 @@ final readonly class LogHealth
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->health, ModuleHealth::HEALTH_VALUES, true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogHygiene.php
+++ b/app/Actions/LogHygiene.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleHygiene;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogHygiene
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -41,6 +44,8 @@ final readonly class LogHygiene
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->showered === null && $this->brushedTeeth === null && $this->skincare === null) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogMood.php
+++ b/app/Actions/LogMood.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleMood;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogMood
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -39,6 +42,8 @@ final readonly class LogMood
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->mood, ModuleMood::MOOD_VALUES, true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogNotes.php
+++ b/app/Actions/LogNotes.php
@@ -10,10 +10,13 @@ use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 final readonly class LogNotes
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -36,6 +39,8 @@ final readonly class LogNotes
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
     }
 
     private function save(): void

--- a/app/Actions/LogPhysicalActivity.php
+++ b/app/Actions/LogPhysicalActivity.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModulePhysicalActivity;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogPhysicalActivity
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -41,6 +44,8 @@ final readonly class LogPhysicalActivity
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->hasDonePhysicalActivity !== null && ! in_array($this->hasDonePhysicalActivity, ['yes', 'no'], true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogPrimaryObligation.php
+++ b/app/Actions/LogPrimaryObligation.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModulePrimaryObligation;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogPrimaryObligation
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -39,6 +42,8 @@ final readonly class LogPrimaryObligation
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->primaryObligation, ModulePrimaryObligation::PRIMARY_OBLIGATIONS, true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogSexualActivity.php
+++ b/app/Actions/LogSexualActivity.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleSexualActivity;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogSexualActivity
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -40,6 +43,8 @@ final readonly class LogSexualActivity
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->hadSexualActivity === null && $this->sexualActivityType === null) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogShopping.php
+++ b/app/Actions/LogShopping.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleShopping;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogShopping
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -43,6 +46,8 @@ final readonly class LogShopping
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->hasShopped === null
             && $this->shoppingTypes === null

--- a/app/Actions/LogSleep.php
+++ b/app/Actions/LogSleep.php
@@ -10,6 +10,7 @@ use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Date;
@@ -17,6 +18,8 @@ use Illuminate\Validation\ValidationException;
 
 final readonly class LogSleep
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -43,6 +46,8 @@ final readonly class LogSleep
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->bedtime === null && $this->wakeUpTime === null) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogSocialDensity.php
+++ b/app/Actions/LogSocialDensity.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleSocialDensity;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogSocialDensity
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -39,6 +42,8 @@ final readonly class LogSocialDensity
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->socialDensity, ModuleSocialDensity::SOCIAL_DENSITY_VALUES, true)) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogTravel.php
+++ b/app/Actions/LogTravel.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleTravel;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogTravel
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -40,6 +43,8 @@ final readonly class LogTravel
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->hasTraveled === null && $this->travelModes === null) {
             throw ValidationException::withMessages([

--- a/app/Actions/LogTypeOfDay.php
+++ b/app/Actions/LogTypeOfDay.php
@@ -10,6 +10,7 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleDayType;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use InvalidArgumentException;
 
@@ -18,6 +19,8 @@ use InvalidArgumentException;
  */
 final readonly class LogTypeOfDay
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -42,6 +45,8 @@ final readonly class LogTypeOfDay
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if (! in_array($this->dayType, ModuleDayType::DAY_TYPES, true)) {
             $dayTypes = implode('", "', ModuleDayType::DAY_TYPES);

--- a/app/Actions/LogWork.php
+++ b/app/Actions/LogWork.php
@@ -10,11 +10,14 @@ use App\Jobs\UpdateUserLastActivityDate;
 use App\Models\JournalEntry;
 use App\Models\ModuleWork;
 use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 
 final readonly class LogWork
 {
+    use PreventPastEntryEdits;
+
     public function __construct(
         private User $user,
         private JournalEntry $entry,
@@ -42,6 +45,8 @@ final readonly class LogWork
         if ($this->entry->journal->user_id !== $this->user->id) {
             throw new ModelNotFoundException('Journal entry not found');
         }
+
+        $this->preventPastEditsAllowed($this->entry);
 
         if ($this->worked === null
             && $this->workMode === null

--- a/app/Traits/PreventPastEntryEdits.php
+++ b/app/Traits/PreventPastEntryEdits.php
@@ -12,9 +12,10 @@ trait PreventPastEntryEdits
 {
     private function preventPastEditsAllowed(JournalEntry $entry, int $days = 7): void
     {
-        if ($this->entry->journal->can_edit_past === false) {
-            $sevenDaysAgo = now()->subDays(7)->startOfDay();
-            $entryDate = Carbon::create($this->entry->year, $this->entry->month, $this->entry->day)->startOfDay();
+        if ($entry->journal->can_edit_past === false) {
+            $sevenDaysAgo = now()->subDays($days)->startOfDay();
+
+            $entryDate = Carbon::create($entry->year, $entry->month, $entry->day)->startOfDay();
             if ($entryDate->lt($sevenDaysAgo)) {
                 throw new ModelNotFoundException('Editing past entries is not allowed for this journal.');
             }

--- a/app/Traits/PreventPastEntryEdits.php
+++ b/app/Traits/PreventPastEntryEdits.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Models\JournalEntry;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Carbon\Carbon;
+
+trait PreventPastEntryEdits
+{
+    private function preventPastEditsAllowed(JournalEntry $entry, int $days = 7): void
+    {
+        if ($this->entry->journal->can_edit_past === false) {
+            $sevenDaysAgo = now()->subDays(7)->startOfDay();
+            $entryDate = Carbon::create($this->entry->year, $this->entry->month, $this->entry->day)->startOfDay();
+            if ($entryDate->lt($sevenDaysAgo)) {
+                throw new ModelNotFoundException('Editing past entries is not allowed for this journal.');
+            }
+        }
+    }
+}

--- a/tests/Unit/Traits/PreventPastEntryEditsTest.php
+++ b/tests/Unit/Traits/PreventPastEntryEditsTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Traits;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Traits\PreventPastEntryEdits;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PreventPastEntryEditsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_allows_editing_entries_from_today(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => false,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => now()->year,
+            'month' => now()->month,
+            'day' => now()->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $testClass->test();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_allows_editing_entries_within_seven_days(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => false,
+        ]);
+        $sixDaysAgo = now()->subDays(6);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $sixDaysAgo->year,
+            'month' => $sixDaysAgo->month,
+            'day' => $sixDaysAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $testClass->test();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_prevents_editing_entries_older_than_seven_days_when_can_edit_past_is_false(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => false,
+        ]);
+        $eightDaysAgo = now()->subDays(8);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $eightDaysAgo->year,
+            'month' => $eightDaysAgo->month,
+            'day' => $eightDaysAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Editing past entries is not allowed for this journal.');
+
+        $testClass->test();
+    }
+
+    #[Test]
+    public function it_prevents_editing_entries_much_older_than_seven_days(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => false,
+        ]);
+        $thirtyDaysAgo = now()->subDays(30);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $thirtyDaysAgo->year,
+            'month' => $thirtyDaysAgo->month,
+            'day' => $thirtyDaysAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Editing past entries is not allowed for this journal.');
+
+        $testClass->test();
+    }
+
+    #[Test]
+    public function it_allows_editing_old_entries_when_can_edit_past_is_true(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => true,
+        ]);
+        $thirtyDaysAgo = now()->subDays(30);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $thirtyDaysAgo->year,
+            'month' => $thirtyDaysAgo->month,
+            'day' => $thirtyDaysAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $testClass->test();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_allows_editing_very_old_entries_when_can_edit_past_is_true(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => true,
+        ]);
+        $oneYearAgo = now()->subDays(365);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $oneYearAgo->year,
+            'month' => $oneYearAgo->month,
+            'day' => $oneYearAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $testClass->test();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_allows_editing_entries_exactly_seven_days_old(): void
+    {
+        $journal = Journal::factory()->create([
+            'can_edit_past' => false,
+        ]);
+        $sevenDaysAgo = now()->subDays(7);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => $sevenDaysAgo->year,
+            'month' => $sevenDaysAgo->month,
+            'day' => $sevenDaysAgo->day,
+        ]);
+
+        $testClass = new class($entry)
+        {
+            use PreventPastEntryEdits;
+
+            public function __construct(private JournalEntry $entry) {}
+
+            public function test(): void
+            {
+                $this->preventPastEditsAllowed($this->entry);
+            }
+        };
+
+        $testClass->test();
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added PreventPastEntryEdits trait: blocks edits to journal entries older than 7 days when a journal's can_edit_past is false.
- Integrated the trait into logging actions (LogBook, LogEnergy, LogHadKidsToday, LogHealth, LogHygiene, LogMood, LogNotes, LogPhysicalActivity, LogPrimaryObligation, LogSexualActivity, LogShopping, LogSleep, LogSocialDensity, LogTravel, LogTypeOfDay, LogWork) so validate() checks now call preventPastEditsAllowed before further validation.
- New trait implementation throws ModelNotFoundException for disallowed past edits and computes the cutoff via a configurable days parameter (default 7).
- Added unit tests (7) covering boundary and typical cases: today, within 7 days, exactly 7 days, older than 7 days, and behavior when can_edit_past is true or false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->