### PR TITLE
chore(views): annotate Blade views with expected data and make includes explicit

### DIFF
--- a/resources/views/app/auth/2fa.blade.php
+++ b/resources/views/app/auth/2fa.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - 2FA form -->

--- a/resources/views/app/auth/confirm-password.blade.php
+++ b/resources/views/app/auth/confirm-password.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Confirm password form -->

--- a/resources/views/app/auth/forgot-password.blade.php
+++ b/resources/views/app/auth/forgot-password.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Forgot password form -->

--- a/resources/views/app/auth/login.blade.php
+++ b/resources/views/app/auth/login.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Login form -->

--- a/resources/views/app/auth/magic-link-sent.blade.php
+++ b/resources/views/app/auth/magic-link-sent.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Login form -->

--- a/resources/views/app/auth/register.blade.php
+++ b/resources/views/app/auth/register.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Login form -->

--- a/resources/views/app/auth/request-magic-link.blade.php
+++ b/resources/views/app/auth/request-magic-link.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Login form -->

--- a/resources/views/app/auth/reset-password.blade.php
+++ b/resources/views/app/auth/reset-password.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Http\Request $request
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Reset password form -->

--- a/resources/views/app/auth/verify-email.blade.php
+++ b/resources/views/app/auth/verify-email.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-guest-layout>
   <div class="grid min-h-screen w-screen grid-cols-1 lg:grid-cols-2">
     <!-- Left side - Login form -->

--- a/resources/views/app/claim.blade.php
+++ b/resources/views/app/claim.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Claim your account') }}

--- a/resources/views/app/journal/create.blade.php
+++ b/resources/views/app/journal/create.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Create journal') }}

--- a/resources/views/app/journal/entry/notes/edit.blade.php
+++ b/resources/views/app/journal/entry/notes/edit.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \App\Models\JournalEntry $entry
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Add a note') }}

--- a/resources/views/app/journal/entry/partials/day_type.blade.php
+++ b/resources/views/app/journal/entry/partials/day_type.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Day type') }}</x-slot>
   <x-slot:emoji>📅</x-slot>

--- a/resources/views/app/journal/entry/partials/energy.blade.php
+++ b/resources/views/app/journal/entry/partials/energy.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Energy') }}</x-slot>
   <x-slot:emoji>⚡️</x-slot>

--- a/resources/views/app/journal/entry/partials/health.blade.php
+++ b/resources/views/app/journal/entry/partials/health.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Health') }}</x-slot>
   <x-slot:emoji>❤️</x-slot>

--- a/resources/views/app/journal/entry/partials/hygiene.blade.php
+++ b/resources/views/app/journal/entry/partials/hygiene.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Hygiene') }}</x-slot>
   <x-slot:emoji>🧼</x-slot>

--- a/resources/views/app/journal/entry/partials/kids.blade.php
+++ b/resources/views/app/journal/entry/partials/kids.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\JournalEntry $entry
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Kids today') }}</x-slot>
   <x-slot:emoji>🧒</x-slot>

--- a/resources/views/app/journal/entry/partials/mood.blade.php
+++ b/resources/views/app/journal/entry/partials/mood.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Mood') }}</x-slot>
   <x-slot:emoji>🙂</x-slot>

--- a/resources/views/app/journal/entry/partials/note.blade.php
+++ b/resources/views/app/journal/entry/partials/note.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <div id="note-container" class="relative h-full w-full overflow-hidden bg-[#fdf9f0] text-gray-900 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_8px_20px_rgba(0,0,0,0.06)] ring-1 ring-black/5 before:pointer-events-none before:absolute before:inset-0 before:bg-[linear-gradient(transparent_1.45rem,_rgba(13,13,13,0.06)_1.45rem,_rgba(13,13,13,0.06)_1.5rem)] before:bg-[length:100%_1.5rem] after:pointer-events-none after:absolute after:inset-y-0 after:left-8 after:w-px after:bg-red-300/70 dark:bg-slate-900 dark:text-gray-100 dark:ring-white/10 dark:before:bg-[linear-gradient(transparent_1.45rem,_rgba(255,255,255,0.08)_1.45rem,_rgba(255,255,255,0.08)_1.5rem)] dark:after:bg-red-400/40">
   <div class="relative z-10 space-y-6 px-8 py-[0.25rem] text-left leading-6 sm:px-8">
     @if (! $module['display_reset'])

--- a/resources/views/app/journal/entry/partials/physical_activity.blade.php
+++ b/resources/views/app/journal/entry/partials/physical_activity.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Physical Activity') }}</x-slot>
   <x-slot:emoji>🏃‍♂️</x-slot>

--- a/resources/views/app/journal/entry/partials/primary_obligation.blade.php
+++ b/resources/views/app/journal/entry/partials/primary_obligation.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Primary obligation') }}</x-slot>
   <x-slot:emoji>🎯</x-slot>

--- a/resources/views/app/journal/entry/partials/sexual_activity.blade.php
+++ b/resources/views/app/journal/entry/partials/sexual_activity.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\JournalEntry $entry
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Sexual activity') }}</x-slot>
   <x-slot:emoji>❤️</x-slot>

--- a/resources/views/app/journal/entry/partials/shopping.blade.php
+++ b/resources/views/app/journal/entry/partials/shopping.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Shopping') }}</x-slot>
   <x-slot:emoji>🛍️</x-slot>

--- a/resources/views/app/journal/entry/partials/sleep.blade.php
+++ b/resources/views/app/journal/entry/partials/sleep.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Sleep tracking') }}</x-slot>
   <x-slot:emoji>🌖</x-slot>

--- a/resources/views/app/journal/entry/partials/social_density.blade.php
+++ b/resources/views/app/journal/entry/partials/social_density.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Social density') }}</x-slot>
   <x-slot:emoji>👥</x-slot>

--- a/resources/views/app/journal/entry/partials/travel.blade.php
+++ b/resources/views/app/journal/entry/partials/travel.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Travel') }}</x-slot>
   <x-slot:emoji>✈️</x-slot>

--- a/resources/views/app/journal/entry/partials/work.blade.php
+++ b/resources/views/app/journal/entry/partials/work.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
 <x-module>
   <x-slot:title>{{ __('Work') }}</x-slot>
   <x-slot:emoji>💼</x-slot>

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -1,3 +1,14 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \App\Models\JournalEntry $entry
+ * @var array<string, mixed> $modules
+ * @var \Illuminate\Support\Collection $years
+ * @var \Illuminate\Support\Collection $months
+ * @var \Illuminate\Support\Collection $days
+ */
+?>
+
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Journal') }}
@@ -72,7 +83,7 @@
         @endif
 
         @if ($journal->show_kids_module)
-          @include('app.journal.entry.partials.kids', ['module' => $modules['kids']])
+          @include('app.journal.entry.partials.kids', ['module' => $modules['kids'], 'entry' => $entry])
         @endif
       </div>
     </div>

--- a/resources/views/app/journal/index.blade.php
+++ b/resources/views/app/journal/index.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\Collection $journals
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Dashboard') }}

--- a/resources/views/app/journal/settings/management/index.blade.php
+++ b/resources/views/app/journal/settings/management/index.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Maintenance') }}
@@ -15,11 +22,11 @@
 
     <section class="p-4 sm:p-8">
       <div class="mx-auto flex max-w-2xl flex-col gap-y-8 sm:px-0">
-        @include('app.journal.settings.partials.edit-past')
+        @include('app.journal.settings.partials.edit-past', ['journal' => $journal, 'errors' => $errors])
 
-        @include('app.journal.settings.partials.rename')
+        @include('app.journal.settings.partials.rename', ['journal' => $journal, 'errors' => $errors])
 
-        @include('app.journal.settings.partials.delete')
+        @include('app.journal.settings.partials.delete', ['journal' => $journal])
       </div>
     </section>
   </div>

--- a/resources/views/app/journal/settings/modules/index.blade.php
+++ b/resources/views/app/journal/settings/modules/index.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ */
+?>
+
 <x-app-layout :journal="$journal">
   <x-slot:title>
     {{ __('Modules') }}
@@ -14,7 +20,7 @@
 
     <section class="p-4 sm:p-8">
       <div class="flex w-full flex-col gap-y-8">
-        @include('app.journal.settings.partials.modules')
+        @include('app.journal.settings.partials.modules', ['journal' => $journal])
       </div>
     </section>
   </div>

--- a/resources/views/app/journal/settings/partials/delete.blade.php
+++ b/resources/views/app/journal/settings/partials/delete.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ */
+?>
+
 <x-box>
   <x-slot:title>
     {{ __('Delete journal') }}

--- a/resources/views/app/journal/settings/partials/edit-past.blade.php
+++ b/resources/views/app/journal/settings/partials/edit-past.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>{{ __('Editing capabilities') }}</x-slot>
   <x-slot:description>

--- a/resources/views/app/journal/settings/partials/modules.blade.php
+++ b/resources/views/app/journal/settings/partials/modules.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ */
+?>
+
 <div class="flex flex-col gap-4" x-data="{ activeTab: 'all' }">
   <h2 class="font-semi-bold mb-1 text-lg">{{ __('Modules') }}</h2>
   <div class="mb-2 flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400">

--- a/resources/views/app/journal/settings/partials/rename.blade.php
+++ b/resources/views/app/journal/settings/partials/rename.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>{{ __('Rename journal') }}</x-slot>
 

--- a/resources/views/app/journal/settings/partials/sidebar.blade.php
+++ b/resources/views/app/journal/settings/partials/sidebar.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ */
+?>
+
 <aside class="flex-col border-b border-gray-200 bg-white px-4 py-4 sm:flex sm:rounded-bl-lg sm:border-r sm:border-b-0 dark:border-gray-700 dark:bg-gray-900">
   <nav class="flex flex-col gap-1">
     <p class="mb-1 text-xs font-medium text-gray-500 uppercase">{{ __('Journal') }}</p>

--- a/resources/views/app/settings/account/index.blade.php
+++ b/resources/views/app/settings/account/index.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Account administration') }}

--- a/resources/views/app/settings/account/partials/delete-account.blade.php
+++ b/resources/views/app/settings/account/partials/delete-account.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-box>
   <x-slot:title>
     {{ __('Delete your account') }}

--- a/resources/views/app/settings/account/partials/prune-account.blade.php
+++ b/resources/views/app/settings/account/partials/prune-account.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-box>
   <x-slot:title>
     {{ __('Prune your account') }}

--- a/resources/views/app/settings/appearance.blade.php
+++ b/resources/views/app/settings/appearance.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-layouts.app :title="__('Appearance | Settings')">
   <div class="flex flex-col items-start">
     @include('partials.settings-heading')

--- a/resources/views/app/settings/emails/index.blade.php
+++ b/resources/views/app/settings/emails/index.blade.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * @var $emails
+/**
+ * @var \Illuminate\Support\Collection $emails
  */
 ?>
 

--- a/resources/views/app/settings/logs/index.blade.php
+++ b/resources/views/app/settings/logs/index.blade.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * @var $logs
+/**
+ * @var \Illuminate\Support\Collection $logs
  */
 ?>
 

--- a/resources/views/app/settings/partials/sidebar.blade.php
+++ b/resources/views/app/settings/partials/sidebar.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <aside class="flex-col border-b border-gray-200 bg-white px-4 py-4 sm:flex sm:rounded-bl-lg sm:border-r sm:border-b-0 dark:border-gray-700 dark:bg-gray-900">
   <nav class="flex flex-col gap-1">
     <p class="mb-1 text-xs font-medium text-gray-500 uppercase">{{ __('Account') }}</p>

--- a/resources/views/app/settings/password.blade.php
+++ b/resources/views/app/settings/password.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-layouts.app :title="__('Password | Settings')">
   <section class="w-full">
     @include('partials.settings-heading')

--- a/resources/views/app/settings/profile/index.blade.php
+++ b/resources/views/app/settings/profile/index.blade.php
@@ -1,3 +1,14 @@
+<?php
+/**
+ * @var \App\Models\User $user
+ * @var \Illuminate\Support\Collection $logs
+ * @var \Illuminate\Support\Collection $emails
+ * @var bool $hasMoreLogs
+ * @var bool $hasMoreEmails
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Profile') }}
@@ -17,7 +28,7 @@
     <section class="p-4 sm:p-8">
       <div class="mx-auto flex max-w-4xl flex-col gap-y-8 sm:px-0">
         <!-- update user details -->
-        @include('app.settings.profile.partials.details', ['user' => $user])
+        @include('app.settings.profile.partials.details', ['user' => $user, 'errors' => $errors])
 
         <!-- logs -->
         @include('app.settings.profile.partials.logs', ['logs' => $logs, 'hasMoreLogs' => $hasMoreLogs])

--- a/resources/views/app/settings/profile/partials/details.blade.php
+++ b/resources/views/app/settings/profile/partials/details.blade.php
@@ -1,6 +1,7 @@
 <?php
-/*
+/**
  * @var \App\Models\User $user
+ * @var \Illuminate\Support\ViewErrorBag $errors
  */
 ?>
 

--- a/resources/views/app/settings/profile/partials/emails.blade.php
+++ b/resources/views/app/settings/profile/partials/emails.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \Illuminate\Support\Collection $emails
+ * @var bool $hasMoreEmails
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>{{ __('Emails sent') }}</x-slot>
 

--- a/resources/views/app/settings/profile/partials/logs.blade.php
+++ b/resources/views/app/settings/profile/partials/logs.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \Illuminate\Support\Collection $logs
+ * @var bool $hasMoreLogs
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>{{ __('Logs') }}</x-slot>
   <x-slot:description>

--- a/resources/views/app/settings/security/index.blade.php
+++ b/resources/views/app/settings/security/index.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var \App\Models\User $user
+ * @var \Illuminate\Support\Collection $apiKeys
+ * @var string|null $preferredMethod
+ * @var bool $has2fa
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-app-layout>
   <x-slot:title>
     {{ __('Security and access') }}
@@ -17,13 +27,17 @@
     <section class="p-4 sm:p-8">
       <div class="mx-auto max-w-2xl space-y-6 sm:px-0">
         <!-- user password -->
-        @include('app.settings.security.partials.password', ['user' => $user])
+        @include('app.settings.security.partials.password', ['user' => $user, 'errors' => $errors])
 
         <!-- two factor authentication -->
-        @include('app.settings.security.partials.2fa.index')
+        @include('app.settings.security.partials.2fa.index', [
+          'has2fa' => $has2fa,
+          'preferredMethod' => $preferredMethod,
+          'errors' => $errors,
+        ])
 
         <!-- auto delete account -->
-        @include('app.settings.security.partials.auto-delete')
+        @include('app.settings.security.partials.auto-delete', ['errors' => $errors])
 
         <!-- api keys -->
         @include('app.settings.security.partials.api.index', ['apiKeys' => $apiKeys])

--- a/resources/views/app/settings/security/partials/2fa/index.blade.php
+++ b/resources/views/app/settings/security/partials/2fa/index.blade.php
@@ -1,11 +1,12 @@
 <?php
-/*
- * @var Collection $apiKeys
+/**
  * @var bool $has2fa
+ * @var string|null $preferredMethod
+ * @var \Illuminate\Support\ViewErrorBag $errors
  */
 ?>
 
-@include('app.settings.security.partials.2fa.preferred-method')
+@include('app.settings.security.partials.2fa.preferred-method', ['preferredMethod' => $preferredMethod, 'errors' => $errors])
 
 <x-box padding="p-0">
   <!-- Authenticator app -->

--- a/resources/views/app/settings/security/partials/2fa/new.blade.php
+++ b/resources/views/app/settings/security/partials/2fa/new.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var string $qrCodeSvg
+ * @var string $secret
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-form :action="route('settings.security.2fa.store')" method="post" id="authenticator-app" x-target="authenticator-app notifications" x-target.back="authenticator-app" class="border-b border-gray-200 p-4 dark:border-gray-700">
   <div class="flex flex-col gap-y-4">
     <p>

--- a/resources/views/app/settings/security/partials/2fa/preferred-method.blade.php
+++ b/resources/views/app/settings/security/partials/2fa/preferred-method.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string|null $preferredMethod
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>{{ __('Two-factor authentication') }}</x-slot>
   <x-slot:description>

--- a/resources/views/app/settings/security/partials/2fa/recovery-codes.blade.php
+++ b/resources/views/app/settings/security/partials/2fa/recovery-codes.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<int, string> $recoveryCodes
+ */
+?>
+
 <div id="recovery-codes" class="border-b border-gray-200 p-4 dark:border-gray-700">
   <div class="mb-4 flex items-center">
     <x-phosphor-toolbox class="h-5 w-5 text-gray-500" />

--- a/resources/views/app/settings/security/partials/api/create.blade.php
+++ b/resources/views/app/settings/security/partials/api/create.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-form id="new-api-key-form" x-target="api-key-list new-api-key-form api-key-notification notifications" x-target.back="new-api-key-form" action="{{ route('settings.api-keys.store') }}" method="post" class="space-y-5 rounded-t-lg p-4 first:rounded-t-lg last:rounded-b-lg last:border-0 hover:bg-blue-50 dark:hover:bg-gray-800">
   <div>
     <x-input id="label" :label="__('Label for the API key')" type="text" name="label" required autofocus :error="$errors->get('label')" />

--- a/resources/views/app/settings/security/partials/api/index.blade.php
+++ b/resources/views/app/settings/security/partials/api/index.blade.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * @var \Illuminate\Support\Collection $apiKeys
  */
 ?>

--- a/resources/views/app/settings/security/partials/auto-delete.blade.php
+++ b/resources/views/app/settings/security/partials/auto-delete.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\Support\ViewErrorBag $errors
+ */
+?>
+
 <x-box padding="p-0">
   <x-slot:title>
     {{ __('Auto delete account') }}

--- a/resources/views/app/settings/security/partials/password.blade.php
+++ b/resources/views/app/settings/security/partials/password.blade.php
@@ -1,6 +1,7 @@
 <?php
-/*
+/**
  * @var \App\Models\User $user
+ * @var \Illuminate\Support\ViewErrorBag $errors
  */
 ?>
 

--- a/resources/views/app/upgrade/index.blade.php
+++ b/resources/views/app/upgrade/index.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-app-layout>
   <x-breadcrumb :items="[
     ['label' => __('Dashboard'), 'route' => route('journal.index')],

--- a/resources/views/components/action-message.blade.php
+++ b/resources/views/components/action-message.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var string $on
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'on',
 ])

--- a/resources/views/components/auth-session-status.blade.php
+++ b/resources/views/components/auth-session-status.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string|null $status
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'status',
 ])

--- a/resources/views/components/box.blade.php
+++ b/resources/views/components/box.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string|null $title
+ * @var string|null $description
+ * @var string $padding
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'title' => null,
   'padding' => 'p-4',

--- a/resources/views/components/breadcrumb.blade.php
+++ b/resources/views/components/breadcrumb.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<int, array<string, mixed>> $items
+ */
+?>
+
 @props([
   'items',
 ])

--- a/resources/views/components/button/danger.blade.php
+++ b/resources/views/components/button/danger.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var string|null $href
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var \Illuminate\View\ComponentSlot|null $icon
+ */
+?>
+
 @props([
   'href',
 ])

--- a/resources/views/components/button/index.blade.php
+++ b/resources/views/components/button/index.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var string|null $href
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var \Illuminate\View\ComponentSlot|null $icon
+ */
+?>
+
 @props([
   'href',
 ])

--- a/resources/views/components/button/no.blade.php
+++ b/resources/views/components/button/no.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string $name
+ * @var string $value
+ * @var string $xTarget
+ * @var string $action
+ * @var string|bool $selected
+ */
+?>
+
 @props([
   'name' => '',
   'value' => '',

--- a/resources/views/components/button/secondary.blade.php
+++ b/resources/views/components/button/secondary.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string|null $href
+ * @var bool $turbo
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var \Illuminate\View\ComponentSlot|null $icon
+ */
+?>
+
 @props([
   'href',
   'turbo' => false,

--- a/resources/views/components/button/yes.blade.php
+++ b/resources/views/components/button/yes.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string $name
+ * @var string $value
+ * @var string $xTarget
+ * @var string $action
+ * @var string|bool $selected
+ */
+?>
+
 @props([
   'name' => '',
   'value' => '',

--- a/resources/views/components/dropdown-link.blade.php
+++ b/resources/views/components/dropdown-link.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 <a {{ $attributes->merge(['class' => 'block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-hidden focus:bg-gray-100 dark:focus:bg-gray-800 transition duration-150 ease-in-out']) }}>
   {{ $slot }}
 </a>

--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string $align
+ * @var string $width
+ * @var string $contentClasses
+ * @var \Illuminate\View\ComponentSlot $trigger
+ * @var \Illuminate\View\ComponentSlot $content
+ */
+?>
+
 @props(['align' => 'right', 'width' => '48', 'contentClasses' => 'bg-white py-1 dark:bg-gray-700'])
 
 @php

--- a/resources/views/components/error.blade.php
+++ b/resources/views/components/error.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var array<int, string>|string|null $messages
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'messages',
 ])

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 <footer {{ $attributes->class(['flex w-full max-w-[1920px] items-center pr-4 pl-9']) }}>
   <div class="flex py-3 text-sm text-gray-600">
     <div class="flex">&copy; {{ config('app.name') }} &middot; {{ now()->format('Y') }}</div>

--- a/resources/views/components/form.blade.php
+++ b/resources/views/components/form.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string $method
+ * @var string $action
+ * @var bool $upload
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props(['method' => 'get', 'action' => '', 'upload' => false])
 
 <form method="{{ $method !== 'get' ? 'post' : 'get' }}" action="{{ $action }}" {{ $attributes->merge(['enctype' => $upload ? 'multipart/form-data' : null]) }}>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\Journal|null $journal
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @if (Auth::user()->isInTrial())
   <div class="relative mx-auto flex w-full flex-wrap items-center justify-center gap-4 bg-linear-to-r from-amber-100 via-yellow-50 to-white px-4 py-2 text-center ring-1 ring-amber-200/70 transition duration-150 sm:flex-nowrap sm:justify-center sm:text-left dark:from-yellow-900/40 dark:via-amber-900/20 dark:to-gray-900 dark:ring-amber-700/40" x-data="{ showTooltip: false }" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false">
     <div class="flex items-center gap-3">

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -1,3 +1,15 @@
+<?php
+/**
+ * @var string $src
+ * @var string $srcset
+ * @var string $alt
+ * @var int|string $width
+ * @var int|string $height
+ * @var string $loading
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'src',
   'alt',

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,3 +1,22 @@
+<?php
+/**
+ * @var string $size
+ * @var string $type
+ * @var bool $passManagerDisabled
+ * @var bool $required
+ * @var string|null $id
+ * @var string|null $label
+ * @var string|null $autocomplete
+ * @var string|null $error
+ * @var string|null $placeholder
+ * @var string|null $value
+ * @var string|null $help
+ * @var bool $autofocus
+ * @var bool $disabled
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'size' => 'base',
   'type' => 'text',

--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var string|null $value
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'value',
 ])

--- a/resources/views/components/link.blade.php
+++ b/resources/views/components/link.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var bool $turbo
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'turbo' => true,
 ])

--- a/resources/views/components/logo.blade.php
+++ b/resources/views/components/logo.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var int|string $width
+ * @var int|string $height
+ */
+?>
+
 @props(['width' => 400, 'height' => 400])
 
 <svg xmlns="http://www.w3.org/2000/svg" width="{{ $width }}" height="{{ $height }}" viewBox="0 0 400 400" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">

--- a/resources/views/components/marketing/docs/attribute.blade.php
+++ b/resources/views/components/marketing/docs/attribute.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var string $name
+ * @var string $type
+ * @var string $description
+ * @var bool $required
+ */
+?>
+
 @props([
   'name',
   'type',

--- a/resources/views/components/marketing/docs/code.blade.php
+++ b/resources/views/components/marketing/docs/code.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var string|null $title
+ * @var string|null $verb
+ * @var string|null $verbClass
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'title' => 'Code',
   'verb' => '',

--- a/resources/views/components/marketing/docs/h1.blade.php
+++ b/resources/views/components/marketing/docs/h1.blade.php
@@ -1,1 +1,7 @@
+<?php
+/**
+ * @var string $title
+ */
+?>
+
 <h1 class="mb-6 text-4xl font-normal">{{ $title }}</h1>

--- a/resources/views/components/marketing/docs/h2.blade.php
+++ b/resources/views/components/marketing/docs/h2.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string $id
+ * @var string $title
+ */
+?>
+
 <h2 id="{{ $id }}" class="group relative mb-4 text-2xl font-semibold">
   <a href="#{{ $id }}" class="before:absolute before:-left-6 before:font-normal before:text-red-500 before:opacity-0 before:transition-opacity before:duration-200 before:content-['#'] group-hover:before:opacity-70">
     {{ $title }}

--- a/resources/views/components/marketing/docs/query-parameters.blade.php
+++ b/resources/views/components/marketing/docs/query-parameters.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 <div x-cloak x-data="{ open: false }" class="mb-8">
   <div @click="open = !open" x-bind:class="open ? 'border-b border-gray-200 dark:border-gray-700' : ''" class="mb-2 flex cursor-pointer items-center justify-between pb-2">
     <p class="font-semibold">Query parameters</p>

--- a/resources/views/components/marketing/docs/response-attributes.blade.php
+++ b/resources/views/components/marketing/docs/response-attributes.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 <div x-cloak x-data="{ open: false }">
   <div @click="open = !open" x-bind:class="open ? 'border-b border-gray-200 dark:border-gray-700' : ''" class="flex cursor-pointer items-center justify-between pb-2">
     <p class="font-semibold">Response attributes</p>

--- a/resources/views/components/marketing/docs/table-of-content.blade.php
+++ b/resources/views/components/marketing/docs/table-of-content.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var array<int, array<string, string>> $items
+ */
+?>
+
 <div class="mb-8 rounded-lg border border-gray-200 p-4 dark:border-gray-700 dark:bg-gray-900">
   <p class="mb-2 text-xs">Table of contents</p>
 

--- a/resources/views/components/marketing/docs/url-parameters.blade.php
+++ b/resources/views/components/marketing/docs/url-parameters.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 <div x-cloak x-data="{ open: false }" class="mb-8">
   <div @click="open = !open" x-bind:class="open ? 'border-b border-gray-200 dark:border-gray-700' : ''" class="mb-2 flex cursor-pointer items-center justify-between pb-2">
     <p class="font-semibold">URL parameters</p>

--- a/resources/views/components/marketing/footer.blade.php
+++ b/resources/views/components/marketing/footer.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <footer class="border-t border-gray-200 bg-white pt-12 pb-8 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
   <div class="mx-auto max-w-7xl px-6 lg:px-0">
     <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5">

--- a/resources/views/components/marketing/header.blade.php
+++ b/resources/views/components/marketing/header.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div class="w-full" x-data="{ mobileMenuOpen: false }">
   <!-- main nav -->
   <nav class="max-w-8xl mx-auto flex h-12 items-center justify-between border-b border-gray-300 bg-zinc-100 px-3 sm:px-6 dark:border-slate-600 dark:bg-gray-800 dark:text-slate-200">

--- a/resources/views/components/meta.blade.php
+++ b/resources/views/components/meta.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string|null $title
+ */
+?>
+
 <title>{{ $title ?? config('app.name') }}</title>
 
 <meta charset="utf-8" />

--- a/resources/views/components/module.blade.php
+++ b/resources/views/components/module.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string|null $title
+ * @var string|null $emoji
+ * @var \Illuminate\View\ComponentSlot|null $action
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'title' => null,
   'emoji' => null,

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,3 +1,17 @@
+<?php
+/**
+ * @var bool $required
+ * @var string|null $id
+ * @var string|null $label
+ * @var string|array|null $error
+ * @var string|null $value
+ * @var string|null $help
+ * @var array<int|string, string> $options
+ * @var string|int|null $selected
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'required' => false,
   'id' => null,

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,3 +1,13 @@
+<?php
+/**
+ * @var string $placeholder
+ * @var string $height
+ * @var string $xRef
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'placeholder' => '',
   'height' => 'h-auto min-h-[80px]',

--- a/resources/views/components/toaster.blade.php
+++ b/resources/views/components/toaster.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div class="pointer-events-none fixed bottom-0 z-50 flex w-full flex-col items-end p-4 sm:p-6 rtl:items-start" role="status" aria-live="polite">
   <div x-sync id="notifications" class="pointer-events-auto relative w-full max-w-xs transform transition duration-300 ease-in-out">
     @if ($message = Session::get('status'))

--- a/resources/views/components/toggle.blade.php
+++ b/resources/views/components/toggle.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var string $name
+ * @var bool $checked
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'name',
   'checked' => false,

--- a/resources/views/components/tooltip.blade.php
+++ b/resources/views/components/tooltip.blade.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * @var string $text
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'text',
 ])

--- a/resources/views/components/trix-input.blade.php
+++ b/resources/views/components/trix-input.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var string $id
+ * @var string $name
+ * @var string $value
+ * @var \Illuminate\View\ComponentAttributeBag $attributes
+ */
+?>
+
 @props([
   'id',
   'name',

--- a/resources/views/instance/index.blade.php
+++ b/resources/views/instance/index.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var \Illuminate\Support\Collection $users
+ * @var int $totalUsers
+ * @var int $last7DaysUsers
+ * @var int $last30DaysUsers
+ */
+?>
+
 <x-app-layout>
   @include('instance.partials.banner')
 

--- a/resources/views/instance/partials/banner.blade.php
+++ b/resources/views/instance/partials/banner.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <!-- Admin panel indicator -->
 <div class="rounded-t-lg border-b border-yellow-200 bg-yellow-50">
   <div class="mx-auto flex max-w-7xl items-center justify-center gap-x-3 px-4 py-2 sm:px-6 lg:px-8">

--- a/resources/views/instance/partials/menu.blade.php
+++ b/resources/views/instance/partials/menu.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <!-- menu -->
 <nav class="mb-10">
   <ul class="flex flex-wrap gap-4 rounded-lg border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-900">

--- a/resources/views/instance/show.blade.php
+++ b/resources/views/instance/show.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \App\Models\User $user
+ * @var \Illuminate\Support\Collection $logs
+ */
+?>
+
 <x-app-layout>
   @include('instance.partials.banner')
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,7 +1,15 @@
+<?php
+/**
+ * @var \App\Models\Journal|null $journal
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var string|null $title
+ */
+?>
+
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
   <head>
-    @include('components.meta')
+    @include('components.meta', ['title' => $title ?? null])
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var array<int, array<string, mixed>> $breadcrumbItems
+ * @var \Illuminate\View\ComponentSlot $slot
+ */
+?>
+
 @props([
   'marketingPage',
   'breadcrumbItems' => [],

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -1,7 +1,14 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var string|null $title
+ */
+?>
+
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
   <head>
-    @include('components.meta')
+    @include('components.meta', ['title' => $title ?? null])
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/layouts/marketing.blade.php
+++ b/resources/views/layouts/marketing.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var \Illuminate\View\ComponentSlot $slot
+ * @var string|null $title
+ */
+?>
+
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
   <head>
@@ -5,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content="{{ csrf_token() }}" />
 
-    @include('components.meta')
+    @include('components.meta', ['title' => $title ?? null])
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/mail/account/automatically-destroyed-text.blade.php
+++ b/resources/views/mail/account/automatically-destroyed-text.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var int $age
+ */
+?>
+
 Account deleted
 
 An account has been automatically deleted because of inactivity.

--- a/resources/views/mail/account/automatically-destroyed.blade.php
+++ b/resources/views/mail/account/automatically-destroyed.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var int $age
+ */
+?>
+
 <x-mail::message>
 Account deleted
 

--- a/resources/views/mail/account/destroyed-text.blade.php
+++ b/resources/views/mail/account/destroyed-text.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string $activeSince
+ * @var string $reason
+ */
+?>
+
 Account deleted
 
 An account has been deleted.

--- a/resources/views/mail/account/destroyed.blade.php
+++ b/resources/views/mail/account/destroyed.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string $activeSince
+ * @var string $reason
+ */
+?>
+
 <x-mail::message>
 Account deleted
 

--- a/resources/views/mail/account/user-ip-changed-text.blade.php
+++ b/resources/views/mail/account/user-ip-changed-text.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string $email
+ * @var string $ip
+ */
+?>
+
 Hi,
 
 Your {{ config('app.name') }} account {{ $email }} was recently signed-in from a new location, device or browser.

--- a/resources/views/mail/account/user-ip-changed.blade.php
+++ b/resources/views/mail/account/user-ip-changed.blade.php
@@ -1,3 +1,10 @@
+<?php
+/**
+ * @var string $email
+ * @var string $ip
+ */
+?>
+
 <x-mail::message>
 Hi,
 

--- a/resources/views/mail/api/created-text.blade.php
+++ b/resources/views/mail/api/created-text.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $label
+ */
+?>
+
 New API key created
 
 A personal API key with the label {{ $label }} has been created on {{ config('app.name') }}.

--- a/resources/views/mail/api/created.blade.php
+++ b/resources/views/mail/api/created.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $label
+ */
+?>
+
 <x-mail::message>
   # New API key created
 

--- a/resources/views/mail/api/destroyed-text.blade.php
+++ b/resources/views/mail/api/destroyed-text.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $label
+ */
+?>
+
 API key removed
 
 A personal API key with the label {{ $label }} has been removed on {{ config('app.name') }}.

--- a/resources/views/mail/api/destroyed.blade.php
+++ b/resources/views/mail/api/destroyed.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $label
+ */
+?>
+
 <x-mail::message>
   # API key removed
 

--- a/resources/views/mail/auth/login-failed-text.blade.php
+++ b/resources/views/mail/auth/login-failed-text.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 Login attempt on {{ config('app.name') }}
 
 A user (hopefully it's you) tried to login to your account but failed.

--- a/resources/views/mail/auth/login-failed.blade.php
+++ b/resources/views/mail/auth/login-failed.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-mail::message>
 # Login attempt on {{ config('app.name') }}
 

--- a/resources/views/mail/auth/magic-link-created-text.blade.php
+++ b/resources/views/mail/auth/magic-link-created-text.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $link
+ */
+?>
+
 Your login link for {{ config('app.name') }}
 
 {{ $link }}

--- a/resources/views/mail/auth/magic-link-created.blade.php
+++ b/resources/views/mail/auth/magic-link-created.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @var string $link
+ */
+?>
+
 <x-mail::message>
 # Your login link for {{ config('app.name') }}
 

--- a/resources/views/marketing/docs/api/account/account.blade.php
+++ b/resources/views/marketing/docs/api/account/account.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/account/api-management.blade.php
+++ b/resources/views/marketing/docs/api/account/api-management.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/account/emails.blade.php
+++ b/resources/views/marketing/docs/api/account/emails.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/account/logs.blade.php
+++ b/resources/views/marketing/docs/api/account/logs.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/account/profile.blade.php
+++ b/resources/views/marketing/docs/api/account/profile.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/authentication.blade.php
+++ b/resources/views/marketing/docs/api/authentication.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/entries/journal-entry.blade.php
+++ b/resources/views/marketing/docs/api/entries/journal-entry.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/introduction.blade.php
+++ b/resources/views/marketing/docs/api/introduction.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/journals/journals.blade.php
+++ b/resources/views/marketing/docs/api/journals/journals.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/day-type.blade.php
+++ b/resources/views/marketing/docs/api/modules/day-type.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/energy.blade.php
+++ b/resources/views/marketing/docs/api/modules/energy.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[[
   'label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/health.blade.php
+++ b/resources/views/marketing/docs/api/modules/health.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/hygiene.blade.php
+++ b/resources/views/marketing/docs/api/modules/hygiene.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/kids.blade.php
+++ b/resources/views/marketing/docs/api/modules/kids.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[[
   'label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/mood.blade.php
+++ b/resources/views/marketing/docs/api/modules/mood.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/physical-activity.blade.php
+++ b/resources/views/marketing/docs/api/modules/physical-activity.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/primary-obligation.blade.php
+++ b/resources/views/marketing/docs/api/modules/primary-obligation.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/sexual-activity.blade.php
+++ b/resources/views/marketing/docs/api/modules/sexual-activity.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/shopping.blade.php
+++ b/resources/views/marketing/docs/api/modules/shopping.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/sleep.blade.php
+++ b/resources/views/marketing/docs/api/modules/sleep.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/social-density.blade.php
+++ b/resources/views/marketing/docs/api/modules/social-density.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/travel.blade.php
+++ b/resources/views/marketing/docs/api/modules/travel.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/modules/work.blade.php
+++ b/resources/views/marketing/docs/api/modules/work.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout :breadcrumbItems="[
   ['label' => 'Home', 'route' => route('marketing.index')],
   ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],

--- a/resources/views/marketing/docs/api/partials/api-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/api-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": [</div>
 <div class="pl-8">{</div>

--- a/resources/views/marketing/docs/api/partials/email-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/email-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": {</div>
 <div class="pl-8">

--- a/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing.docs.response-attributes>
   <x-marketing.docs.attribute name="type" type="string" description="The type of the resource." />
   <x-marketing.docs.attribute name="id" type="string" description="The ID of the journal entry." />

--- a/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": {</div>
 <div class="pl-8">

--- a/resources/views/marketing/docs/api/partials/journal-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": {</div>
 <div class="pl-8">

--- a/resources/views/marketing/docs/api/partials/log-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/log-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": {</div>
 <div class="pl-8">

--- a/resources/views/marketing/docs/api/partials/profile-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/profile-response.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <div>{</div>
 <div class="pl-4">"data": {</div>
 <div class="pl-8">

--- a/resources/views/marketing/docs/concepts/hierarchy-structure.blade.php
+++ b/resources/views/marketing/docs/concepts/hierarchy-structure.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout>
   <div class="grid grid-cols-1 gap-x-16 lg:grid-cols-[1fr_250px]">
     <div class="py-16 sm:border-r sm:border-gray-200 sm:pr-10 dark:sm:border-gray-700">

--- a/resources/views/marketing/docs/concepts/permissions.blade.php
+++ b/resources/views/marketing/docs/concepts/permissions.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout>
   <div class="grid grid-cols-1 gap-x-16 lg:grid-cols-[1fr_250px]">
     <div class="py-16 sm:border-r sm:border-gray-200 sm:pr-10 dark:sm:border-gray-700">

--- a/resources/views/marketing/docs/index.blade.php
+++ b/resources/views/marketing/docs/index.blade.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 <x-marketing-docs-layout>
   <h1 class="mb-6 text-2xl font-bold">Index</h1>
 </x-marketing-docs-layout>

--- a/resources/views/marketing/index.blade.php
+++ b/resources/views/marketing/index.blade.php
@@ -1,1 +1,7 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
 bla

--- a/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
+++ b/tests/Feature/Controllers/App/Settings/ProfileControllerTest.php
@@ -16,9 +16,19 @@ final class ProfileControllerTest extends TestCase
     #[Test]
     public function it_shows_the_profile_page(): void
     {
-        $this->actingAs(User::factory()->create());
+        $user = User::factory()->create();
 
-        $this->get('/settings/profile')->assertOk();
+        $this
+            ->actingAs($user)
+            ->get('/settings/profile')
+            ->assertOk()
+            ->assertViewHasAll([
+                'user',
+                'logs',
+                'emails',
+                'hasMoreLogs',
+                'hasMoreEmails',
+            ]);
     }
 
     #[Test]


### PR DESCRIPTION
### Motivation
- Ensure every Blade view documents which variables it expects so IDEs and reviewers know the contract. 
- Remove implicit variable sharing between parent and included views by passing required data explicitly. 
- Make component contracts clearer by adding PHPDoc blocks to component templates. 
- Prevent subtle runtime errors caused by missing view data and improve discoverability for maintainers. 

### Description
- Added PHPDoc header blocks to many Blade templates (app, components, marketing, mail) documenting expected view data and component props. 
- Updated Blade `@include` usages to pass all required variables explicitly to included partials (e.g. settings/profile, journal entry modules, security partials). 
- Annotated component templates and layout files and updated layouts to pass `title` into `components.meta`. 
- Added an assertion in the profile controller feature test to validate the controller provides `user`, `logs`, `emails`, `hasMoreLogs`, and `hasMoreEmails` to the profile view. 

### Testing
- Ran `vendor/bin/pint --dirty` to check formatting, which failed because `vendor/bin/pint` was not found in the environment. 
- Ran `php artisan test tests/Feature/Controllers/App/Settings/ProfileControllerTest.php` to execute the modified test, which failed due to missing `vendor/autoload.php` in the environment. 
- Verified templates and include sites by static inspection and automated updates across the repository; no runtime tests could complete without project dependencies. 
- All changes staged and prepared for review; CI should be run in the full project environment to validate formatting and the test-suite passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640ff376d083209a09d4519b8779c5)