### PR TITLE
feat: add journal entry report view

### DIFF
--- a/app/Http/Controllers/App/Journals/JournalEntryController.php
+++ b/app/Http/Controllers/App/Journals/JournalEntryController.php
@@ -46,4 +46,227 @@ final class JournalEntryController extends Controller
             'modules' => $modules,
         ]);
     }
+
+    public function report(Request $request): View
+    {
+        $journal = $request->attributes->get('journal');
+        $journalEntry = $request->attributes->get('journal_entry');
+
+        $years = JournalHelper::getYears(
+            journal: $journal,
+            selectedYear: $journalEntry->year,
+        );
+
+        $months = JournalHelper::getMonths(
+            journal: $journal,
+            year: $journalEntry->year,
+            selectedMonth: $journalEntry->month,
+        );
+
+        $days = JournalHelper::getDaysInMonth(
+            journal: $journal,
+            year: $journalEntry->year,
+            month: $journalEntry->month,
+            day: $journalEntry->day,
+        );
+
+        $lifeModules = [];
+        $dayModules = [];
+        $leisureModules = [];
+
+        if ($journal->show_sleep_module) {
+            $lifeModules[] = [
+                'title' => __('Sleep tracking'),
+                'emoji' => '🌖',
+                'summary' => __('8h 15m of rest'),
+                'items' => [
+                    ['question' => __('Time you went to sleep'), 'answer' => '22:45'],
+                    ['question' => __('Time you woke up'), 'answer' => '07:00'],
+                ],
+            ];
+        }
+
+        if ($journal->show_travel_module) {
+            $lifeModules[] = [
+                'title' => __('Travel'),
+                'emoji' => '✈️',
+                'summary' => __('Yes, a light commute'),
+                'items' => [
+                    ['question' => __('Have you traveled today?'), 'answer' => __('Yes')],
+                    ['question' => __('How did you travel?'), 'answer' => __('Train, Walking')],
+                ],
+            ];
+        }
+
+        if ($journal->show_shopping_module) {
+            $lifeModules[] = [
+                'title' => __('Shopping'),
+                'emoji' => '🛍️',
+                'summary' => __('Essentials and a small treat'),
+                'items' => [
+                    ['question' => __('Shopped today?'), 'answer' => __('Yes')],
+                    ['question' => __('Shopping type'), 'answer' => __('Groceries, Personal')],
+                    ['question' => __('Intent'), 'answer' => __('Planned')],
+                    ['question' => __('Shopping context'), 'answer' => __('In store, On the way home')],
+                    ['question' => __('Shopping for'), 'answer' => __('Self, Home')],
+                ],
+            ];
+        }
+
+        if ($journal->show_kids_module) {
+            $lifeModules[] = [
+                'title' => __('Kids today'),
+                'emoji' => '🧒',
+                'summary' => __('Afternoon together'),
+                'items' => [
+                    ['question' => __('Did you have the kids today?'), 'answer' => __('Yes')],
+                ],
+            ];
+        }
+
+        if ($journal->show_day_type_module) {
+            $dayModules[] = [
+                'title' => __('Day type'),
+                'emoji' => '📅',
+                'summary' => __('Focused and steady'),
+                'items' => [
+                    ['question' => __('What type of day was it?'), 'answer' => __('Productive')],
+                ],
+            ];
+        }
+
+        if ($journal->show_primary_obligation_module) {
+            $dayModules[] = [
+                'title' => __('Primary obligation'),
+                'emoji' => '🎯',
+                'summary' => __('Top priority today'),
+                'items' => [
+                    ['question' => __('What demanded most of your attention today?'), 'answer' => __('Client project delivery')],
+                ],
+            ];
+        }
+
+        if ($journal->show_work_module) {
+            $dayModules[] = [
+                'title' => __('Work'),
+                'emoji' => '💼',
+                'summary' => __('Deep work with a few meetings'),
+                'items' => [
+                    ['question' => __('Have you worked today?'), 'answer' => __('Yes')],
+                    ['question' => __('How did you work?'), 'answer' => __('Focus blocks, Meetings')],
+                    ['question' => __('How much did you work?'), 'answer' => __('6-8 hours')],
+                    ['question' => __('Did you procrastinate (be honest)?'), 'answer' => __('A little')],
+                ],
+            ];
+        }
+
+        if ($journal->show_health_module) {
+            $dayModules[] = [
+                'title' => __('Health'),
+                'emoji' => '❤️',
+                'summary' => __('Balanced with a mild headache'),
+                'items' => [
+                    ['question' => __('How did you feel today?'), 'answer' => __('Good overall')],
+                ],
+            ];
+        }
+
+        if ($journal->show_hygiene_module) {
+            $dayModules[] = [
+                'title' => __('Hygiene'),
+                'emoji' => '🧼',
+                'summary' => __('Full routine'),
+                'items' => [
+                    ['question' => __('Showered'), 'answer' => __('Yes')],
+                    ['question' => __('Brushed teeth'), 'answer' => __('Yes')],
+                    ['question' => __('Skincare'), 'answer' => __('Yes')],
+                ],
+            ];
+        }
+
+        if ($journal->show_mood_module) {
+            $dayModules[] = [
+                'title' => __('Mood'),
+                'emoji' => '🙂',
+                'summary' => __('Calm and optimistic'),
+                'items' => [
+                    ['question' => __('How was your mood today?'), 'answer' => __('Positive')],
+                ],
+            ];
+        }
+
+        if ($journal->show_energy_module) {
+            $dayModules[] = [
+                'title' => __('Energy'),
+                'emoji' => '⚡️',
+                'summary' => __('Steady, peaking mid-afternoon'),
+                'items' => [
+                    ['question' => __('How was your energy today?'), 'answer' => __('High')],
+                ],
+            ];
+        }
+
+        if ($journal->show_social_density_module) {
+            $dayModules[] = [
+                'title' => __('Social density'),
+                'emoji' => '👥',
+                'summary' => __('A handful of touchpoints'),
+                'items' => [
+                    ['question' => __('How was your social density today?'), 'answer' => __('Moderate')],
+                ],
+            ];
+        }
+
+        if ($journal->show_physical_activity_module) {
+            $leisureModules[] = [
+                'title' => __('Physical Activity'),
+                'emoji' => '🏃‍♂️',
+                'summary' => __('Quick session before dinner'),
+                'items' => [
+                    ['question' => __('Did you do physical activity?'), 'answer' => __('Yes')],
+                    ['question' => __('What type of activity?'), 'answer' => __('Run, Mobility')],
+                    ['question' => __('How intense was it?'), 'answer' => __('Moderate')],
+                ],
+            ];
+        }
+
+        if ($journal->show_sexual_activity_module) {
+            $leisureModules[] = [
+                'title' => __('Sexual activity'),
+                'emoji' => '❤️',
+                'summary' => __('Connection and intimacy'),
+                'items' => [
+                    ['question' => __('Did you have sexual activity?'), 'answer' => __('Yes')],
+                    ['question' => __('What kind of sexual activity?'), 'answer' => __('Affection, Intimacy')],
+                ],
+            ];
+        }
+
+        $reportSections = [
+            [
+                'title' => __('Life'),
+                'description' => __('What happened today'),
+                'modules' => $lifeModules,
+            ],
+            [
+                'title' => __('Day'),
+                'description' => __('What shaped the day'),
+                'modules' => $dayModules,
+            ],
+            [
+                'title' => __('Leisure'),
+                'description' => __('What you did for yourself'),
+                'modules' => $leisureModules,
+            ],
+        ];
+
+        return view('app.journal.entry.report', [
+            'journal' => $journal,
+            'entry' => $journalEntry,
+            'years' => $years,
+            'months' => $months,
+            'days' => $days,
+            'reportSections' => $reportSections,
+        ]);
+    }
 }

--- a/resources/views/app/journal/entry/report.blade.php
+++ b/resources/views/app/journal/entry/report.blade.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @var \App\Models\Journal $journal
+ * @var \App\Models\JournalEntry $entry
+ * @var array<int, array<string, mixed>> $reportSections
+ * @var \Illuminate\Support\Collection $years
+ * @var \Illuminate\Support\Collection $months
+ * @var \Illuminate\Support\Collection $days
+ */
+?>
+
+<x-app-layout :journal="$journal">
+  <x-slot:title>
+    {{ __('Report') }}
+  </x-slot>
+
+  <x-breadcrumb :items="[
+    ['label' => __('Dashboard'), 'route' => route('journal.index')],
+    ['label' => $journal->name, 'route' => route('journal.show', ['slug' => $journal->slug]) ],
+    ['label' => $entry->getDate(), 'route' => route('journal.entry.show', [
+      'slug' => $journal->slug,
+      'year' => $entry->year,
+      'month' => $entry->month,
+      'day' => $entry->day,
+    ]) ],
+    ['label' => __('Report')]
+  ]" />
+
+  <!-- list of years -->
+  @if (count($years) > 1)
+    <div id="years-listing" class="bg-white dark:bg-gray-900">
+      <div class="mx-auto grid divide-x divide-gray-200 border-b border-gray-200 dark:divide-gray-700 dark:border-gray-700" style="grid-template-columns: repeat({{ count($years) }}, minmax(0, 1fr))">
+        @foreach ($years as $year)
+          <a href="{{ $year->url }}" class="group {{ $year->is_selected ? 'border-indigo-200 bg-indigo-50' : '' }} relative cursor-pointer px-2 py-1 text-center transition-colors hover:bg-indigo-50">
+            <div class="text-sm font-medium text-gray-900">{{ $year->year }}</div>
+            <div class="{{ $year->is_selected ? 'scale-x-100' : '' }} absolute bottom-0 left-0 h-0.5 w-full scale-x-0 bg-indigo-600 transition-transform group-hover:scale-x-100"></div>
+          </a>
+        @endforeach
+      </div>
+    </div>
+  @endif
+
+  <!-- list of months -->
+  <div id="months-listing" class="bg-white dark:bg-gray-900">
+    <div class="mx-auto grid grid-cols-12 divide-x divide-gray-200 border-b border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+      @foreach ($months as $month)
+        <a href="{{ $month->url }}" class="group {{ $month->is_selected ? 'border-indigo-200 bg-indigo-50 dark:border-indigo-400/60 dark:bg-indigo-900/40' : '' }} relative cursor-pointer px-2 py-1 text-center transition-colors hover:bg-indigo-50 dark:hover:bg-indigo-900/40">
+          <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $month->month_name }}</div>
+          <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ trans_choice('{0} No entries|{1} :count entry|[2,*] :count entries', $month->entries_count, ['count' => $month->entries_count]) }}</div>
+          <div class="{{ $month->is_selected ? 'scale-x-100' : '' }} absolute bottom-0 left-0 h-0.5 w-full scale-x-0 bg-indigo-600 transition-transform group-hover:scale-x-100"></div>
+        </a>
+      @endforeach
+    </div>
+  </div>
+
+  <!-- list of days -->
+  <div id="days-listing" class="bg-white dark:bg-gray-900">
+    <div class="days-grid-{{ $days->count() }} mx-auto grid divide-x divide-gray-200 dark:divide-gray-700">
+      @foreach ($days as $day)
+        <div class="group {{ $day->is_selected ? 'border-b-indigo-200 bg-indigo-50 dark:border-b-indigo-400/60 dark:bg-indigo-900/40' : '' }} {{ $day->is_today ? 'bg-indigo-50 dark:bg-indigo-900/40' : '' }} relative aspect-square cursor-pointer border-b border-gray-200 text-center transition-colors hover:bg-indigo-50 dark:border-gray-700 dark:hover:bg-indigo-900/40">
+          <a href="{{ $day->url }}" data-turbo="false" class="flex h-full flex-col items-center justify-center">
+            <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $day->day }}</span>
+            <div class="{{ $day->has_content === true ? 'bg-green-500' : 'bg-transparent' }} mt-1 h-1.5 w-1.5 rounded-full"></div>
+          </a>
+        </div>
+      @endforeach
+    </div>
+  </div>
+
+  <div class="border-b border-gray-200 bg-gradient-to-br from-white via-indigo-50 to-indigo-100/40 px-4 py-8 dark:border-gray-700 dark:from-gray-900 dark:via-gray-900 dark:to-indigo-950/30">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-600 dark:text-indigo-400">
+            <span class="inline-flex h-2 w-2 rounded-full bg-indigo-500"></span>
+            {{ __('Journal report') }}
+          </div>
+          <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $entry->getDate() }}</h1>
+          <p class="text-sm text-gray-600 dark:text-gray-300">
+            {{ __('A narrative snapshot of the day, organized by category and module.') }}
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-3">
+          <div class="rounded-2xl border border-indigo-200/70 bg-white px-4 py-3 shadow-sm dark:border-indigo-500/30 dark:bg-gray-900">
+            <div class="text-xs font-medium uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-300">{{ __('Modules') }}</div>
+            <div class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {{ collect($reportSections)->sum(fn ($section) => count($section['modules'])) }}
+            </div>
+          </div>
+          <div class="rounded-2xl border border-indigo-200/70 bg-white px-4 py-3 shadow-sm dark:border-indigo-500/30 dark:bg-gray-900">
+            <div class="text-xs font-medium uppercase tracking-[0.18em] text-indigo-500 dark:text-indigo-300">{{ __('Sections') }}</div>
+            <div class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ count($reportSections) }}</div>
+          </div>
+          <a
+            href="{{ route('journal.entry.show', ['slug' => $journal->slug, 'year' => $entry->year, 'month' => $entry->month, 'day' => $entry->day]) }}"
+            class="inline-flex items-center justify-center rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition hover:border-indigo-300 hover:text-indigo-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-indigo-400 dark:hover:text-indigo-300"
+          >
+            {{ __('Back to entry') }}
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-10">
+    @foreach ($reportSections as $section)
+      <section class="flex flex-col gap-6">
+        <div class="flex flex-col gap-2">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ $section['title'] }}</h2>
+              <p class="text-sm text-gray-600 dark:text-gray-400">{{ $section['description'] }}</p>
+            </div>
+            <span class="rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-300">
+              {{ trans_choice('{0} No module|{1} :count module|[2,*] :count modules', count($section['modules']), ['count' => count($section['modules'])]) }}
+            </span>
+          </div>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+          @foreach ($section['modules'] as $module)
+            <div class="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex items-center gap-3">
+                  <span class="text-2xl">{{ $module['emoji'] }}</span>
+                  <div class="flex flex-col gap-1">
+                    <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ $module['title'] }}</h3>
+                    @if ($module['summary'])
+                      <p class="text-sm text-gray-500 dark:text-gray-400">{{ $module['summary'] }}</p>
+                    @endif
+                  </div>
+                </div>
+              </div>
+
+              <div class="flex flex-col gap-3">
+                @foreach ($module['items'] as $item)
+                  <div class="flex flex-col gap-1 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3 dark:border-gray-800 dark:bg-gray-950">
+                    <p class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">{{ $item['question'] }}</p>
+                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $item['answer'] }}</p>
+                  </div>
+                @endforeach
+              </div>
+            </div>
+          @endforeach
+        </div>
+      </section>
+    @endforeach
+  </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,8 @@ Route::middleware(['auth', 'verified', 'throttle:60,1', 'set.locale'])->group(fu
             Route::middleware(['journal.entry'])->group(function (): void {
                 Route::get('journals/{slug}/entries/{year}/{month}/{day}', [Journals\JournalEntryController::class, 'show'])
                     ->name('journal.entry.show');
+                Route::get('journals/{slug}/entries/{year}/{month}/{day}/report', [Journals\JournalEntryController::class, 'report'])
+                    ->name('journal.entry.report');
 
                 // notes
                 Route::get('journals/{slug}/entries/{year}/{month}/{day}/notes/edit', [Journals\Notes\NotesController::class, 'edit'])->name('journal.entry.notes.edit');

--- a/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
@@ -56,6 +56,27 @@ final class JournalEntryControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_shows_a_journal_entry_report(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'day' => 15,
+            'month' => 6,
+            'year' => 2024,
+        ]);
+
+        $response = $this->actingAs($user)->get(
+            "/journals/{$journal->slug}/entries/2024/6/15/report",
+        );
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
     public function it_redirects_guests_to_login(): void
     {
         $journal = Journal::factory()->create();


### PR DESCRIPTION
### Motivation

- Provide a readable, attractive "report" representation of a `JournalEntry` that summarizes module answers instead of showing forms. 
- Expose the report at the entry URL followed by `/report` so users can quickly view a narrative version of their day. 
- Keep the top navigation and the years/months/days navigation to preserve context and navigation continuity. 
- Use module toggles to decide which modules appear in the report and show sample answers for now.

### Description

- Add a new route `journals/{slug}/entries/{year}/{month}/{day}/report` in `routes/web.php` mapped to `JournalEntryController::report`.
- Implement `report(Request $request): View` in `app/Http/Controllers/App/Journals/JournalEntryController.php` to build per-module summary data (fake/sample answers) driven by the journal's module flags.
- Create a styled Blade view at `resources/views/app/journal/entry/report.blade.php` that reuses the existing year/month/day navigation and renders sections (Life / Day / Leisure) with module cards and question/answer items.
- Add a feature test `it_shows_a_journal_entry_report` to `tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php` that requests the `/report` route and asserts a `200` response.

### Testing

- Added a PHPUnit feature test file `tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php` covering the new `/report` route; the test asserts `200` for an authorized user.
- Attempted to run `vendor/bin/pint --dirty` but it failed due to missing `vendor/autoload.php` in the environment so formatting could not be verified. 
- Attempted to run the single feature test with `php artisan test tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php` but it failed due to missing `vendor/autoload.php` so tests could not execute here. 
- Attempted the project-wide test `composer journalos:unit` but it also failed for the same missing `vendor` dependencies, so CI/local test execution is still required to confirm passing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965329362a083208e7c7045438b387d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New journal entry report view**: Added a new "report" representation for journal entries that presents module answers as a readable narrative instead of forms
- **Report endpoint**: New route `journals/{slug}/entries/{year}/{month}/{day}/report` provides access to the report view
- **Three-section layout**: Report is organized into Life, Day, and Leisure sections, each containing relevant modules with questions and answers
- **Dynamic module display**: Modules appear conditionally based on journal configuration flags (sleep, travel, shopping, kids, day type, mood, energy, etc.)
- **Enhanced readability**: Module answers are presented with titles, emojis, summaries, and formatted Q&A items instead of form inputs
- **Navigation preserved**: Year/month/day navigation and existing timeline controls maintained from the standard entry view
- **Test coverage**: Added feature test `it_shows_a_journal_entry_report` to verify the report endpoint returns a 200 response for authorized users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->