### PR TITLE
fix: align hygiene buttons with module styles

### DIFF
--- a/app/View/Presenters/HygieneModulePresenter.php
+++ b/app/View/Presenters/HygieneModulePresenter.php
@@ -32,8 +32,11 @@ final readonly class HygieneModulePresenter
                 'month' => $this->entry->month,
                 'day' => $this->entry->day,
             ]),
+            'showered' => $module?->showered,
             'showered_options' => $this->yesNoOptions($module?->showered),
+            'brushed_teeth' => $module?->brushed_teeth,
             'brushed_teeth_options' => $this->brushedTeethOptions($module?->brushed_teeth),
+            'skincare' => $module?->skincare,
             'skincare_options' => $this->yesNoOptions($module?->skincare),
             'display_reset' => $displayReset,
         ];

--- a/resources/views/app/journal/entry/partials/hygiene.blade.php
+++ b/resources/views/app/journal/entry/partials/hygiene.blade.php
@@ -24,16 +24,8 @@
       <div class="flex flex-col gap-2">
         <p>{{ __('Showered') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-          @foreach ($module['showered_options'] as $option)
-            <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-              <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
-                <input type="hidden" name="showered" value="{{ $option['value'] }}" />
-                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
-                  {{ $option['label'] }}
-                </button>
-              </x-form>
-            </div>
-          @endforeach
+          <x-button.yes name="showered" value="yes" x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" selected="{{ $module['showered'] === 'yes' }}" />
+          <x-button.no name="showered" value="no" x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" selected="{{ $module['showered'] === 'no' }}" />
         </div>
       </div>
 
@@ -44,7 +36,7 @@
             <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
               <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
                 <input type="hidden" name="brushed_teeth" value="{{ $option['value'] }}" />
-                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
+                <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-green-50 dark:hover:bg-green-900/40">
                   {{ $option['label'] }}
                 </button>
               </x-form>
@@ -56,16 +48,8 @@
       <div class="flex flex-col gap-2">
         <p>{{ __('Skincare') }}</p>
         <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
-          @foreach ($module['skincare_options'] as $option)
-            <div class="flex-1 border-r border-gray-200 first:overflow-hidden first:rounded-l-lg last:rounded-r-lg last:border-r-0 dark:border-gray-700">
-              <x-form x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" method="put">
-                <input type="hidden" name="skincare" value="{{ $option['value'] }}" />
-                <button type="submit" class="{{ $option['is_selected'] ? 'bg-blue-50 font-bold dark:bg-blue-900/40' : '' }} flex h-full w-full cursor-pointer items-center justify-center p-2 text-center hover:bg-blue-50 dark:hover:bg-blue-900/40">
-                  {{ $option['label'] }}
-                </button>
-              </x-form>
-            </div>
-          @endforeach
+          <x-button.yes name="skincare" value="yes" x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" selected="{{ $module['skincare'] === 'yes' }}" />
+          <x-button.no name="skincare" value="no" x-target="hygiene-container notifications hygiene-reset days-listing months-listing" :action="$module['hygiene_url']" selected="{{ $module['skincare'] === 'no' }}" />
         </div>
       </div>
     </div>

--- a/tests/Unit/Presenters/HygieneModulePresenterTest.php
+++ b/tests/Unit/Presenters/HygieneModulePresenterTest.php
@@ -34,8 +34,11 @@ final class HygieneModulePresenterTest extends TestCase
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('hygiene_url', $result);
+        $this->assertArrayHasKey('showered', $result);
         $this->assertArrayHasKey('showered_options', $result);
+        $this->assertArrayHasKey('brushed_teeth', $result);
         $this->assertArrayHasKey('brushed_teeth_options', $result);
+        $this->assertArrayHasKey('skincare', $result);
         $this->assertArrayHasKey('skincare_options', $result);
         $this->assertArrayHasKey('reset_url', $result);
         $this->assertArrayHasKey('display_reset', $result);
@@ -121,6 +124,9 @@ final class HygieneModulePresenterTest extends TestCase
         $this->assertTrue($result['showered_options'][0]['is_selected']);
         $this->assertTrue($result['brushed_teeth_options'][2]['is_selected']);
         $this->assertTrue($result['skincare_options'][1]['is_selected']);
+        $this->assertSame('yes', $result['showered']);
+        $this->assertSame('pm', $result['brushed_teeth']);
+        $this->assertSame('no', $result['skincare']);
     }
 
     #[Test]


### PR DESCRIPTION
### Motivation

- Make the Hygiene module UI consistent with other modules by using the shared Yes/No button components.
- Ensure the "Brushed teeth" option uses the green module styling like other modules.
- Expose hygiene values in the presenter so views and tests can inspect the selected values.

### Description

- Replaced manual per-option forms for `showered` and `skincare` with the shared components `x-button.yes` and `x-button.no` in `resources/views/app/journal/entry/partials/hygiene.blade.php`.
- Restyled the `brushed_teeth` selected state from blue to green by changing the selected class to `bg-green-50 font-bold dark:bg-green-900/40`.
- Added `showered`, `brushed_teeth`, and `skincare` keys to `HygieneModulePresenter::build()` so views can read the current values directly.
- Updated `tests/Unit/Presenters/HygieneModulePresenterTest.php` to assert the new keys and verify the presented values when a `ModuleHygiene` exists.

### Testing

- Ran `vendor/bin/pint --dirty` to check formatting (failed because `vendor/bin/pint` is not present in the environment).
- Ran `php artisan test tests/Unit/Presenters/HygieneModulePresenterTest.php` (failed due to missing `vendor/autoload.php` in the sandbox).
- Ran `composer journalos:unit` (failed for the same missing `vendor/autoload.php` issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a5b65f9883208f854bca37b9f237)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Hygiene module consistency**: Replaced per-option forms with shared Yes/No button components for the Showered and Skincare options to match other module UI styles
- **Updated "Brushed teeth" styling**: Changed selected state color scheme from blue to green (green module styling) for visual consistency
- **Exposed hygiene values**: Added `showered`, `brushed_teeth`, and `skincare` keys to `HygieneModulePresenter` for direct value inspection in views and tests
- **Enhanced testability**: Updated unit tests to verify newly exposed hygiene values and ensure presenter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->