### PR TITLE
feat: add route to marketing page

### DIFF
--- a/resources/views/app/auth/2fa.blade.php
+++ b/resources/views/app/auth/2fa.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/app/auth/confirm-password.blade.php
+++ b/resources/views/app/auth/confirm-password.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/app/auth/forgot-password.blade.php
+++ b/resources/views/app/auth/forgot-password.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/app/auth/login.blade.php
+++ b/resources/views/app/auth/login.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 
@@ -54,7 +54,7 @@
               {{--
                 <div class="mt-4 mb-0">
                 <x-turnstile data-size="flexible" />
-                
+
                 <x-input-error :messages="$errors->get('cf-turnstile-response')" class="mt-2" />
                 </div>
               --}}

--- a/resources/views/app/auth/magic-link-sent.blade.php
+++ b/resources/views/app/auth/magic-link-sent.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/app/auth/register.blade.php
+++ b/resources/views/app/auth/register.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 
@@ -68,7 +68,7 @@
               {{--
                 <div class="mt-4 mb-0">
                 <x-turnstile data-size="flexible" />
-                
+
                 <x-input-error :messages="$errors->get('cf-turnstile-response')" class="mt-2" />
                 </div>
               --}}

--- a/resources/views/app/auth/request-magic-link.blade.php
+++ b/resources/views/app/auth/request-magic-link.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/app/auth/reset-password.blade.php
+++ b/resources/views/app/auth/reset-password.blade.php
@@ -12,7 +12,7 @@
         @if (config('journalos.show_marketing_site'))
           <p class="group mb-10 flex items-center gap-x-1 text-sm text-gray-600">
             <x-phosphor-arrow-left class="h-4 w-4 transition-transform duration-150 group-hover:-translate-x-1" />
-            <x-link href="" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
+            <x-link href="{{ route('marketing.index') }}" class="group-hover:underline">{{ __('Back to the marketing website') }}</x-link>
           </p>
         @endif
 

--- a/resources/views/components/marketing/header.blade.php
+++ b/resources/views/components/marketing/header.blade.php
@@ -64,15 +64,15 @@
     <!-- Right side - user menu -->
     @if (Auth::check())
       <div class="relative ms-3 flex items-center gap-x-3">
-        <a href="{{ route('login') }}" class="group flex items-center gap-x-2 rounded-sm border border-b-3 border-gray-400 px-2 py-1 text-sm transition-colors duration-150 hover:bg-white dark:border-slate-500 dark:text-slate-100 dark:hover:bg-gray-700/60">
+        <a href="{{ route('login') }}" data-turbo="true" class="group flex items-center gap-x-2 rounded-sm border border-b-3 border-gray-400 px-2 py-1 text-sm transition-colors duration-150 hover:bg-white dark:border-slate-500 dark:text-slate-100 dark:hover:bg-gray-700/60">
           <x-phosphor-door class="h-4 w-4 text-gray-500" />
           {{ __('Go to your account') }}
         </a>
       </div>
     @else
       <div class="flex items-center gap-x-5">
-        <a href="{{ route('journal.index') }}" class="text-sm text-gray-700 dark:text-slate-200">Sign in</a>
-        <a href="{{ route('register') }}" class="rounded-md bg-blue-600 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-blue-600">Get started</a>
+        <a href="{{ route('journal.index') }}" data-turbo="true" class="text-sm text-gray-700 dark:text-slate-200">Sign in</a>
+        <a href="{{ route('register') }}" data-turbo="true" class="rounded-md bg-blue-600 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-blue-600">Get started</a>
       </div>
     @endif
   </nav>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Added marketing.index route to authentication pages**: Updated all authentication view templates (login, register, 2FA, password reset, magic link) to use the proper `route('marketing.index')` helper for "Back to marketing website" links instead of empty href placeholders
- **Enabled Turbo Drive navigation**: Added `data-turbo="true"` attributes to authentication-related navigation links in the marketing header component (user menu login, sign-in, and get started links) for improved performance with Turbo Drive page transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->