### PR TITLE
feat: clear cloudflare cache

### DIFF
--- a/app/Http/Controllers/Marketing/CloudflarePurgeMarketingController.php
+++ b/app/Http/Controllers/Marketing/CloudflarePurgeMarketingController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Marketing;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+use App\Http\Controllers\Controller;
+
+final class CloudflarePurgeMarketingController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $ts  = (string) $request->query('ts', '');
+        $sig = (string) $request->query('sig', '');
+
+        if (!$this->isValidSignature($ts, $sig)) {
+            return response('Unauthorized', 401);
+        }
+
+        $middleware = (string) $request->query('middleware', 'marketing');
+        $appUrl = rtrim((string) config('app.url'), '/');
+
+        $urls = collect(Route::getRoutes())
+            ->filter(fn($route) => in_array('GET', $route->methods(), true) || in_array('HEAD', $route->methods(), true))
+            ->filter(fn($route) => in_array($middleware, $route->gatherMiddleware(), true))
+            ->map(fn($route) => $route->uri())
+            ->filter(fn($uri) => !Str::contains($uri, '{')) // safety
+            ->map(fn($uri) => $uri === '/' ? $appUrl . '/' : $appUrl . '/' . ltrim($uri, '/'))
+            ->unique()
+            ->values();
+
+        if ($urls->isEmpty()) {
+            return response()->json(['ok' => true, 'purged' => 0, 'urls' => []]);
+        }
+
+        $zoneId = config('services.cloudflare.zone_id');
+        $token  = config('services.cloudflare.api_token');
+
+        $chunkSize = (int) config('services.cloudflare.purge_chunk', 30);
+
+        $purged = 0;
+        foreach ($urls->chunk($chunkSize) as $chunk) {
+            $res = Http::withToken($token)->post(
+                "https://api.cloudflare.com/client/v4/zones/{$zoneId}/purge_cache",
+                ['files' => $chunk->all()]
+            );
+
+            if (!$res->ok() || $res->json('success') !== true) {
+                return response()->json([
+                    'ok' => false,
+                    'status' => $res->status(),
+                    'body' => $res->json(),
+                ], 500);
+            }
+
+            $purged += $chunk->count();
+        }
+
+        return response()->json([
+            'ok' => true,
+            'purged' => $purged,
+            'urls' => $urls, // optional; remove if you don't want to expose
+        ]);
+    }
+
+    private function isValidSignature(string $ts, string $sig): bool
+    {
+        if ($ts === '' || $sig === '') return false;
+        if (abs(time() - (int) $ts) > 300) return false;
+
+        $secret = (string) config('services.cloudflare.purge_secret');
+        $expected = hash_hmac('sha256', $ts, $secret);
+
+        return hash_equals($expected, $sig);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -37,4 +37,10 @@ return [
         ],
     ],
 
+    'cloudflare' => [
+        'zone_id' => env('CLOUDFLARE_ZONE_ID'),
+        'api_token' => env('CLOUDFLARE_API_TOKEN'),
+        'purge_secret' => env('CLOUDFLARE_PURGE_SECRET'),
+        'purge_chunk' => env('CLOUDFLARE_PURGE_CHUNK', 30),
+    ],
 ];

--- a/routes/marketing.php
+++ b/routes/marketing.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Marketing\CloudflarePurgeMarketingController;
 use App\Http\Controllers\Marketing\Docs;
 use App\Http\Controllers\Marketing\MarketingController;
 use Illuminate\Support\Facades\Route;
 
+Route::get('/infra/cloudflare/purge-marketing', CloudflarePurgeMarketingController::class);
+
 Route::middleware(['marketing'])->group(function (): void {
+
     Route::get('/', [MarketingController::class, 'index'])->name('marketing.index');
     Route::get('/docs', [Docs\DocController::class, 'index'])->name('marketing.docs.index');
     Route::get('/docs/concepts/hierarchical-structure', [Docs\Concepts\HierarchicalStructureController::class, 'index'])->name('marketing.docs.concepts.hierarchical-structure');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Cloudflare Cache Purging

- **New Feature**: Added automatic Cloudflare cache purging capability for marketing routes
  - New controller endpoint: `GET /infra/cloudflare/purge-marketing`
  - Validates requests using timestamp and HMAC signature authentication (5-minute tolerance)
  - Collects and purges all marketing middleware routes from Cloudflare cache
  
- **Configuration**: Added Cloudflare settings to `config/services.php`
  - `zone_id` and `api_token` for Cloudflare API authentication
  - `purge_secret` for request validation
  - `purge_chunk` size configuration (default: 30 URLs per batch)

- **Implementation Details**:
  - Automatically filters out dynamic/parameterized routes
  - Processes URL purges in configurable batches
  - Returns detailed JSON response with purge status and affected URLs
  - Includes error handling for failed Cloudflare API requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->