### PR TITLE
feat: create default layout for journals

### DIFF
--- a/app/Actions/CreateDefaultLayoutForJournal.php
+++ b/app/Actions/CreateDefaultLayoutForJournal.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Journal;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Support\Facades\DB;
+
+final class CreateDefaultLayoutForJournal
+{
+    public function __construct(
+        private readonly Journal $journal,
+    ) {}
+
+    public function execute(): void
+    {
+        /** @var Encrypter $encrypter */
+        $encrypter = app(Encrypter::class);
+
+        $layoutId = DB::table('layouts')->insertGetId([
+            'journal_id' => $this->journal->id,
+            'name' => $encrypter->encrypt('Default', false),
+            'columns_count' => 3,
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $modules = [
+            // Column 1: Body & Health
+            1 => ['health', 'hygiene', 'energy', 'physical_activity', 'sleep'],
+            // Column 2: Mind & Work
+            2 => ['mood', 'work', 'day_type', 'primary_obligation', 'shopping'],
+            // Column 3: Movement & Social
+            3 => ['travel', 'social_density'],
+        ];
+
+        $insertData = [];
+        foreach ($modules as $columnNumber => $moduleKeys) {
+            $position = 1;
+            foreach ($moduleKeys as $moduleKey) {
+                $insertData[] = [
+                    'layout_id' => $layoutId,
+                    'module_key' => $moduleKey,
+                    'column_number' => $columnNumber,
+                    'position' => $position,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ];
+                $position++;
+            }
+        }
+
+        DB::table('layout_modules')->insert($insertData);
+    }
+}

--- a/app/Actions/CreateJournal.php
+++ b/app/Actions/CreateJournal.php
@@ -26,6 +26,7 @@ final class CreateJournal
         $this->validate();
         $this->create();
         $this->generateSlug();
+        $this->addDefaultLayout();
         $this->updateUserLastActivityDate();
         $this->log();
 
@@ -56,6 +57,11 @@ final class CreateJournal
             'user_id' => $this->user->id,
             'name' => $this->name,
         ]);
+    }
+
+    private function addDefaultLayout(): void
+    {
+        (new CreateDefaultLayoutForJournal($this->journal))->execute();
     }
 
     private function generateSlug(): void

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,163 +2,163 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/energy</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/health</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/hygiene</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/kids</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/mood</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/shopping</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/social-density</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/primary-obligation</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sexual-activity</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-15T22:03:53+00:00</lastmod>
+    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>

--- a/resources/views/components/meta.blade.php
+++ b/resources/views/components/meta.blade.php
@@ -10,7 +10,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="csrf-token" content="{{ csrf_token() }}" />
 
-<link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml" />
+<link rel="icon" href="{{ asset('favicon/favicon.svg') }}" type="image/svg+xml" />
 
 <meta name="description" content="{{ config('journalos.description') }}" />
 <link rel="icon" type="image/png" href="{{ asset('favicon/favicon-96x96.png') }}" sizes="96x96" />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,7 +19,7 @@
     <x-header :journal="$journal" />
 
     <main class="flex flex-1 flex-col px-2 py-px">
-      <div class="mx-auto flex w-full grow flex-col items-stretch rounded-lg shadow-xs ring-1 ring-[#E6E7E9] dark:ring-gray-800">
+      <div class="mx-auto flex w-full grow flex-col items-stretch rounded-lg shadow-xs ring-1 ring-[#E6E7E9] dark:ring-gray-800  bg-gray-50 dark:bg-gray-950">
         {{ $slot }}
       </div>
     </main>

--- a/tests/Unit/Actions/CreateDefaultLayoutForJournalTest.php
+++ b/tests/Unit/Actions/CreateDefaultLayoutForJournalTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\CreateDefaultLayoutForJournal;
+use App\Models\Journal;
+use App\Models\Layout;
+use App\Models\LayoutModule;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CreateDefaultLayoutForJournalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_creates_default_layout_with_three_columns(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        (new CreateDefaultLayoutForJournal($journal))->execute();
+
+        $layout = Layout::query()
+            ->where('journal_id', $journal->id)
+            ->first();
+
+        $this->assertNotNull($layout);
+        $this->assertEquals('Default', $layout->name);
+        $this->assertEquals(3, $layout->columns_count);
+        $this->assertTrue($layout->is_active);
+    }
+
+    #[Test]
+    public function it_adds_all_modules_except_sexual_activity_and_kids(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        (new CreateDefaultLayoutForJournal($journal))->execute();
+
+        $layout = Layout::query()
+            ->where('journal_id', $journal->id)
+            ->first();
+
+        $moduleKeys = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->pluck('module_key')
+            ->toArray();
+
+        $this->assertNotContains('sexual_activity', $moduleKeys);
+        $this->assertNotContains('kids', $moduleKeys);
+
+        $this->assertContains('health', $moduleKeys);
+        $this->assertContains('hygiene', $moduleKeys);
+        $this->assertContains('energy', $moduleKeys);
+        $this->assertContains('physical_activity', $moduleKeys);
+        $this->assertContains('sleep', $moduleKeys);
+        $this->assertContains('mood', $moduleKeys);
+        $this->assertContains('work', $moduleKeys);
+        $this->assertContains('day_type', $moduleKeys);
+        $this->assertContains('primary_obligation', $moduleKeys);
+        $this->assertContains('shopping', $moduleKeys);
+        $this->assertContains('travel', $moduleKeys);
+        $this->assertContains('social_density', $moduleKeys);
+    }
+
+    #[Test]
+    public function it_organizes_modules_by_theme_in_three_columns(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        (new CreateDefaultLayoutForJournal($journal))->execute();
+
+        $layout = Layout::query()
+            ->where('journal_id', $journal->id)
+            ->first();
+
+        $column1Modules = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('column_number', 1)
+            ->orderBy('position')
+            ->pluck('module_key')
+            ->toArray();
+
+        $this->assertEquals(['health', 'hygiene', 'energy', 'physical_activity', 'sleep'], $column1Modules);
+
+        $column2Modules = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('column_number', 2)
+            ->orderBy('position')
+            ->pluck('module_key')
+            ->toArray();
+
+        $this->assertEquals(['mood', 'work', 'day_type', 'primary_obligation', 'shopping'], $column2Modules);
+
+        $column3Modules = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('column_number', 3)
+            ->orderBy('position')
+            ->pluck('module_key')
+            ->toArray();
+
+        $this->assertEquals(['travel', 'social_density'], $column3Modules);
+    }
+
+    #[Test]
+    public function it_assigns_correct_position_to_each_module(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        (new CreateDefaultLayoutForJournal($journal))->execute();
+
+        $layout = Layout::query()
+            ->where('journal_id', $journal->id)
+            ->first();
+
+        $healthModule = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('module_key', 'health')
+            ->first();
+
+        $this->assertEquals(1, $healthModule->column_number);
+        $this->assertEquals(1, $healthModule->position);
+
+        $sleepModule = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('module_key', 'sleep')
+            ->first();
+
+        $this->assertEquals(1, $sleepModule->column_number);
+        $this->assertEquals(5, $sleepModule->position);
+
+        $socialDensityModule = LayoutModule::query()
+            ->where('layout_id', $layout->id)
+            ->where('module_key', 'social_density')
+            ->first();
+
+        $this->assertEquals(3, $socialDensityModule->column_number);
+        $this->assertEquals(2, $socialDensityModule->position);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New Feature**: Automatically create default layout when a new journal is created with 3 columns
- **Default Layout Configuration**: Includes 13 pre-selected modules (health, hygiene, energy, physical activity, sleep, mood, work, day type, primary obligation, shopping, travel, social density) organized into themed columns
- **Module Exclusions**: Sexual activity and kids modules are excluded from the default layout
- **UI Improvements**: Enhanced main content container with light/dark mode background colors (bg-gray-50 / dark:bg-gray-950)
- **Asset Path Update**: Favicon link updated to use new subdirectory path (favicon/favicon.svg)
- **Comprehensive Testing**: Added 4 unit tests validating layout creation, module selection, column organization, and position assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->