### PR TITLE
feat: apply layouts on journal entry view

### DIFF
--- a/app/Http/Controllers/App/Journals/JournalEntryController.php
+++ b/app/Http/Controllers/App/Journals/JournalEntryController.php
@@ -35,7 +35,7 @@ final class JournalEntryController extends Controller
             day: $journalEntry->day,
         );
 
-        $modules = new JournalEntryPresenter($journalEntry)->build();
+        $payload = new JournalEntryPresenter($journalEntry)->build();
 
         return view('app.journal.entry.show', [
             'journal' => $journal,
@@ -43,7 +43,9 @@ final class JournalEntryController extends Controller
             'years' => $years,
             'months' => $months,
             'days' => $days,
-            'modules' => $modules,
+            'columns' => $payload['columns'],
+            'notes' => $payload['notes'],
+            'layoutColumnsCount' => $payload['layout_columns_count'],
         ]);
     }
 }

--- a/app/View/Presenters/JournalEntryPresenter.php
+++ b/app/View/Presenters/JournalEntryPresenter.php
@@ -20,7 +20,7 @@ final readonly class JournalEntryPresenter
         return [
             'columns' => $columns,
             'notes' => $notes,
-            'layout_columns_count' => $layout?->columns_count ?? 0,
+            'layout_columns_count' => $layout->columns_count ?? 0,
         ];
     }
 

--- a/app/View/Presenters/JournalEntryPresenter.php
+++ b/app/View/Presenters/JournalEntryPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\View\Presenters;
 
+use App\Models\Layout;
 use App\Models\JournalEntry;
 
 final readonly class JournalEntryPresenter
@@ -12,108 +13,159 @@ final readonly class JournalEntryPresenter
 
     public function build(): array
     {
-        if ($this->entry->journal->show_sleep_module) {
-            $sleep = new SleepModulePresenter($this->entry)->build('20:00', '06:00');
-        } else {
-            $sleep = [];
-        }
-
-        if ($this->entry->journal->show_work_module) {
-            $work = new WorkModulePresenter($this->entry)->build();
-        } else {
-            $work = [];
-        }
-
-        if ($this->entry->journal->show_travel_module) {
-            $travel = new TravelModulePresenter($this->entry)->build();
-        } else {
-            $travel = [];
-        }
-
-        if ($this->entry->journal->show_shopping_module) {
-            $shopping = new ShoppingModulePresenter($this->entry)->build();
-        } else {
-            $shopping = [];
-        }
-
-        if ($this->entry->journal->show_kids_module) {
-            $kids = new KidsModulePresenter($this->entry)->build();
-        } else {
-            $kids = [];
-        }
-
-        if ($this->entry->journal->show_day_type_module) {
-            $dayType = new DayTypeModulePresenter($this->entry)->build();
-        } else {
-            $dayType = [];
-        }
-
-        if ($this->entry->journal->show_primary_obligation_module) {
-            $primaryObligation = new PrimaryObligationModulePresenter($this->entry)->build();
-        } else {
-            $primaryObligation = [];
-        }
-
-        if ($this->entry->journal->show_physical_activity_module) {
-            $physicalActivity = new PhysicalActivityModulePresenter($this->entry)->build();
-        } else {
-            $physicalActivity = [];
-        }
-
-        if ($this->entry->journal->show_health_module) {
-            $health = new HealthModulePresenter($this->entry)->build();
-        } else {
-            $health = [];
-        }
-
-        if ($this->entry->journal->show_hygiene_module) {
-            $hygiene = new HygieneModulePresenter($this->entry)->build();
-        } else {
-            $hygiene = [];
-        }
-
-        if ($this->entry->journal->show_mood_module) {
-            $mood = new MoodModulePresenter($this->entry)->build();
-        } else {
-            $mood = [];
-        }
-
-        if ($this->entry->journal->show_sexual_activity_module) {
-            $sexualActivity = new SexualActivityModulePresenter($this->entry)->build();
-        } else {
-            $sexualActivity = [];
-        }
-
-        if ($this->entry->journal->show_energy_module) {
-            $energy = new EnergyModulePresenter($this->entry)->build();
-        } else {
-            $energy = [];
-        }
-
-        if ($this->entry->journal->show_social_density_module) {
-            $socialDensity = new SocialDensityModulePresenter($this->entry)->build();
-        } else {
-            $socialDensity = [];
-        }
-
+        $layout = $this->resolveLayout();
+        $columns = $this->buildColumns($layout);
         $notes = new NotesPresenter($this->entry)->build();
 
         return [
-            'sleep' => $sleep,
-            'work' => $work,
-            'travel' => $travel,
-            'shopping' => $shopping,
-            'kids' => $kids,
-            'day_type' => $dayType,
-            'primary_obligation' => $primaryObligation,
-            'physical_activity' => $physicalActivity,
-            'health' => $health,
-            'hygiene' => $hygiene,
-            'mood' => $mood,
-            'sexual_activity' => $sexualActivity,
-            'energy' => $energy,
-            'social_density' => $socialDensity,
+            'columns' => $columns,
             'notes' => $notes,
+            'layout_columns_count' => $layout?->columns_count ?? 0,
         ];
+    }
+
+    /**
+     * @return array<int, array<int, array{key: string, view: string, data: array<string, mixed>}>>
+     */
+    private function buildColumns(?Layout $layout): array
+    {
+        $columns = [];
+
+        if (! $layout) {
+            return $columns;
+        }
+
+        for ($column = 1; $column <= $layout->columns_count; $column++) {
+            $columns[$column] = [];
+        }
+
+        $layoutModules = $layout->layoutModules()
+            ->orderBy('column_number')
+            ->orderBy('position')
+            ->get();
+
+        foreach ($layoutModules as $layoutModule) {
+            if (! $this->isModuleVisible($layoutModule->module_key)) {
+                continue;
+            }
+
+            $module = $this->buildModulePayload($layoutModule->module_key);
+
+            if (! $module) {
+                continue;
+            }
+
+            $columns[$layoutModule->column_number][] = $module;
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @return array{key: string, view: string, data: array<string, mixed>}|null
+     */
+    private function buildModulePayload(string $moduleKey): ?array
+    {
+        return match ($moduleKey) {
+            'sleep' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.sleep',
+                'data' => ['module' => (new SleepModulePresenter($this->entry))->build('20:00', '06:00')],
+            ],
+            'work' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.work',
+                'data' => ['module' => (new WorkModulePresenter($this->entry))->build()],
+            ],
+            'travel' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.travel',
+                'data' => ['module' => (new TravelModulePresenter($this->entry))->build()],
+            ],
+            'shopping' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.shopping',
+                'data' => ['module' => (new ShoppingModulePresenter($this->entry))->build()],
+            ],
+            'kids' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.kids',
+                'data' => [
+                    'entry' => $this->entry,
+                    'module' => (new KidsModulePresenter($this->entry))->build(),
+                ],
+            ],
+            'day_type' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.day_type',
+                'data' => ['module' => (new DayTypeModulePresenter($this->entry))->build()],
+            ],
+            'primary_obligation' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.primary_obligation',
+                'data' => ['module' => (new PrimaryObligationModulePresenter($this->entry))->build()],
+            ],
+            'physical_activity' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.physical_activity',
+                'data' => ['module' => (new PhysicalActivityModulePresenter($this->entry))->build()],
+            ],
+            'health' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.health',
+                'data' => ['module' => (new HealthModulePresenter($this->entry))->build()],
+            ],
+            'hygiene' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.hygiene',
+                'data' => ['module' => (new HygieneModulePresenter($this->entry))->build()],
+            ],
+            'mood' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.mood',
+                'data' => ['module' => (new MoodModulePresenter($this->entry))->build()],
+            ],
+            'sexual_activity' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.sexual_activity',
+                'data' => [
+                    'entry' => $this->entry,
+                    'module' => (new SexualActivityModulePresenter($this->entry))->build(),
+                ],
+            ],
+            'energy' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.energy',
+                'data' => ['module' => (new EnergyModulePresenter($this->entry))->build()],
+            ],
+            'social_density' => [
+                'key' => $moduleKey,
+                'view' => 'app.journal.entry.partials.social_density',
+                'data' => ['module' => (new SocialDensityModulePresenter($this->entry))->build()],
+            ],
+            default => null,
+        };
+    }
+
+    private function isModuleVisible(string $moduleKey): bool
+    {
+        $attribute = 'show_' . $moduleKey . '_module';
+
+        if (! array_key_exists($attribute, $this->entry->journal->getAttributes())) {
+            return false;
+        }
+
+        return (bool) $this->entry->journal->{$attribute};
+    }
+
+    private function resolveLayout(): ?Layout
+    {
+        if ($this->entry->layout_id) {
+            return $this->entry->layout;
+        }
+
+        return $this->entry->journal->layouts()
+            ->where('is_active', true)
+            ->first();
     }
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,163 +2,163 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     <url>
     <loc>https://journalos.cloud/</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/hierarchical-structure</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/concepts/permissions</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/authentication</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/profile</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/api-management</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/logs</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/emails</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/account</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journals</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/journal-entries</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/day-type</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/energy</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/health</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/hygiene</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/kids</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/mood</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/shopping</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/social-density</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/physical-activity</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/primary-obligation</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sexual-activity</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/sleep</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/travel</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>
     <url>
     <loc>https://journalos.cloud/docs/api/modules/work</loc>
-    <lastmod>2026-01-15T22:20:33+00:00</lastmod>
+    <lastmod>2026-01-15T22:37:05+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
             </url>

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -2,7 +2,9 @@
 /**
  * @var \App\Models\Journal $journal
  * @var \App\Models\JournalEntry $entry
- * @var array<string, mixed> $modules
+ * @var array<int, array<int, array{key: string, view: string, data: array<string, mixed>}>> $columns
+ * @var array<string, mixed> $notes
+ * @var int $layoutColumnsCount
  * @var \Illuminate\Support\Collection $years
  * @var \Illuminate\Support\Collection $months
  * @var \Illuminate\Support\Collection $days
@@ -75,83 +77,24 @@
   @endif
 
   <!-- entry content -->
-  <div class="grid grid-cols-4 gap-4 rounded-b-lg bg-gray-50 dark:bg-gray-950">
-    <!-- Life lane -->
-    <div class="py-4 pl-4">
-      <!-- modules -->
-      <div class="space-y-2"></div>
-    </div>
+  @php
+    $columnCount = $layoutColumnsCount > 0 ? $layoutColumnsCount : count($columns);
+    $gridColumns = $columnCount + 1;
+  @endphp
 
-    <!-- Day lane -->
-    <div class="py-4">
-      <!-- modules -->
-      <div class="space-y-2">
-        @if ($journal->show_day_type_module)
-          @include('app.journal.entry.partials.day_type', ['module' => $modules['day_type']])
-        @endif
-
-        @if ($journal->show_primary_obligation_module)
-          @include('app.journal.entry.partials.primary_obligation', ['module' => $modules['primary_obligation']])
-        @endif
-
-        @if ($journal->show_work_module)
-          @include('app.journal.entry.partials.work', ['module' => $modules['work']])
-        @endif
-
-        @if ($journal->show_health_module)
-          @include('app.journal.entry.partials.health', ['module' => $modules['health']])
-        @endif
-
-        @if ($journal->show_hygiene_module)
-          @include('app.journal.entry.partials.hygiene', ['module' => $modules['hygiene']])
-        @endif
-
-        @if ($journal->show_mood_module)
-          @include('app.journal.entry.partials.mood', ['module' => $modules['mood']])
-        @endif
-
-        @if ($journal->show_energy_module)
-          @include('app.journal.entry.partials.energy', ['module' => $modules['energy']])
-        @endif
-
-        @if ($journal->show_social_density_module)
-          @include('app.journal.entry.partials.social_density', ['module' => $modules['social_density']])
-        @endif
+  <div class="grid gap-4 rounded-b-lg bg-gray-50 dark:bg-gray-950" style="grid-template-columns: repeat({{ $gridColumns }}, minmax(0, 1fr))">
+    @foreach ($columns as $column)
+      <div class="{{ $loop->first ? 'pl-4' : '' }} py-4">
+        <div class="space-y-2">
+          @foreach ($column as $module)
+            @include($module['view'], $module['data'])
+          @endforeach
+        </div>
       </div>
-    </div>
+    @endforeach
 
-    <!-- Leisure lane -->
-    <div class="py-4">
-      <!-- modules -->
-      <div class="space-y-2">
-        @if ($journal->show_sleep_module)
-          @include('app.journal.entry.partials.sleep', ['module' => $modules['sleep']])
-        @endif
-
-        @if ($journal->show_travel_module)
-          @include('app.journal.entry.partials.travel', ['module' => $modules['travel']])
-        @endif
-
-        @if ($journal->show_shopping_module)
-          @include('app.journal.entry.partials.shopping', ['module' => $modules['shopping']])
-        @endif
-
-        @if ($journal->show_kids_module)
-          @include('app.journal.entry.partials.kids', ['module' => $modules['kids'], 'entry' => $entry])
-        @endif
-
-        @if ($journal->show_physical_activity_module)
-          @include('app.journal.entry.partials.physical_activity', ['module' => $modules['physical_activity']])
-        @endif
-
-        @if ($journal->show_sexual_activity_module)
-          @include('app.journal.entry.partials.sexual_activity', ['module' => $modules['sexual_activity'], 'entry' => $entry])
-        @endif
-      </div>
-    </div>
-
-    <div class="flex h-full border-l border-gray-200 bg-white">
-      @include('app.journal.entry.partials.note', ['entry' => $entry, 'module' => $modules['notes']])
+    <div class="flex h-full border-l border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+      @include('app.journal.entry.partials.note', ['module' => $notes])
     </div>
   </div>
 </x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,7 +19,7 @@
     <x-header :journal="$journal" />
 
     <main class="flex flex-1 flex-col px-2 py-px">
-      <div class="mx-auto flex w-full grow flex-col items-stretch rounded-lg shadow-xs ring-1 ring-[#E6E7E9] dark:ring-gray-800  bg-gray-50 dark:bg-gray-950">
+      <div class="mx-auto flex w-full grow flex-col items-stretch rounded-lg bg-gray-50 shadow-xs ring-1 ring-[#E6E7E9] dark:bg-gray-950 dark:ring-gray-800">
         {{ $slot }}
       </div>
     </main>

--- a/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/JournalEntryControllerTest.php
@@ -6,10 +6,11 @@ namespace Tests\Feature\Controllers\App\Journals;
 
 use App\Models\Journal;
 use App\Models\JournalEntry;
+use App\Models\Layout;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 final class JournalEntryControllerTest extends TestCase
 {
@@ -22,8 +23,12 @@ final class JournalEntryControllerTest extends TestCase
         $journal = Journal::factory()->create([
             'user_id' => $user->id,
         ]);
+        $layout = Layout::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'layout_id' => $layout->id,
             'day' => 15,
             'month' => 6,
             'year' => 2024,
@@ -41,8 +46,12 @@ final class JournalEntryControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $journal = Journal::factory()->create();
+        $layout = Layout::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'layout_id' => $layout->id,
             'day' => 15,
             'month' => 6,
             'year' => 2024,
@@ -59,8 +68,12 @@ final class JournalEntryControllerTest extends TestCase
     public function it_redirects_guests_to_login(): void
     {
         $journal = Journal::factory()->create();
+        $layout = Layout::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'layout_id' => $layout->id,
             'day' => 15,
             'month' => 6,
             'year' => 2024,

--- a/tests/Unit/Presenters/JournalEntryPresenterTest.php
+++ b/tests/Unit/Presenters/JournalEntryPresenterTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Presenters;
 
 use App\Models\Journal;
 use App\Models\JournalEntry;
+use App\Models\Layout;
+use App\Models\LayoutModule;
 use App\View\Presenters\JournalEntryPresenter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -19,8 +21,36 @@ final class JournalEntryPresenterTest extends TestCase
     public function it_builds_journal_entry_data(): void
     {
         $journal = Journal::factory()->create();
+        $layout = Layout::factory()->create([
+            'journal_id' => $journal->id,
+            'columns_count' => 2,
+            'is_active' => true,
+        ]);
+
+        LayoutModule::factory()->create([
+            'layout_id' => $layout->id,
+            'module_key' => 'sleep',
+            'column_number' => 1,
+            'position' => 1,
+        ]);
+
+        LayoutModule::factory()->create([
+            'layout_id' => $layout->id,
+            'module_key' => 'work',
+            'column_number' => 1,
+            'position' => 2,
+        ]);
+
+        LayoutModule::factory()->create([
+            'layout_id' => $layout->id,
+            'module_key' => 'mood',
+            'column_number' => 2,
+            'position' => 1,
+        ]);
+
         $entry = JournalEntry::factory()->create([
             'journal_id' => $journal->id,
+            'layout_id' => $layout->id,
             'year' => 2024,
             'month' => 12,
             'day' => 25,
@@ -30,12 +60,13 @@ final class JournalEntryPresenterTest extends TestCase
         $result = $presenter->build();
 
         $this->assertIsArray($result);
-        $this->assertArrayHasKey('sleep', $result);
-        $this->assertArrayHasKey('work', $result);
-        $this->assertArrayHasKey('travel', $result);
-        $this->assertArrayHasKey('day_type', $result);
-        $this->assertArrayHasKey('hygiene', $result);
-        $this->assertArrayHasKey('sexual_activity', $result);
-        $this->assertArrayHasKey('energy', $result);
+        $this->assertArrayHasKey('columns', $result);
+        $this->assertArrayHasKey('notes', $result);
+        $this->assertSame(2, $result['layout_columns_count']);
+        $this->assertArrayHasKey(1, $result['columns']);
+        $this->assertArrayHasKey(2, $result['columns']);
+        $this->assertSame('sleep', $result['columns'][1][0]['key']);
+        $this->assertSame('work', $result['columns'][1][1]['key']);
+        $this->assertSame('mood', $result['columns'][2][0]['key']);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Layout-driven journal entry rendering: Journal entries now render modules dynamically from a configured layout instead of a fixed template.
- Dynamic column support: Entry view displays a flexible number of columns determined by layout_columns_count and the layout’s modules.
- Per-entry layout resolution: Entries can store/use their own layout with fallback to the journal’s active layout.
- Centralized module visibility: Module show/hide logic moved to presenter helpers (isModuleVisible) and driven by layout metadata.
- Presenter refactor: JournalEntryPresenter builds a structured payload (columns, notes, layout_columns_count) via resolveLayout, buildColumns and buildModulePayload helpers.
- View refactor: show.blade.php now iterates columns and includes module views from payload data instead of hardcoded module includes.
- Tests updated: Controller and presenter tests now create/associate Layout and LayoutModule records and assert the new columns-based payload.
- Minor non-functional changes: sitemap.xml lastmod timestamps updated; small class-order reorder in app layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->