### PR TITLE
fix: fix turnstile script

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -10,12 +10,12 @@
   <head>
     @include('components.meta', ['title' => $title ?? null])
 
+    @if (config('journalos.show_marketing_site'))
+      <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    @endif
+
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
-
-    @if (config('journalos.show_marketing_site'))
-      @turnstileScripts()
-    @endif
   </head>
   <body class="font-sans text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100">
     <div class="flex min-h-screen flex-col items-center bg-gray-100 pt-6 sm:justify-center sm:pt-0 dark:bg-gray-900">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Replaced inline Turnstile script invocation with explicit Cloudflare Turnstile API script tag
- Turnstile script now conditionally loads only when marketing site is enabled
- Adjusted script loading order in page head for better initialization sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->