### PR TITLE
feat: add meal tracking module

### DIFF
--- a/app/Actions/LogMeal.php
+++ b/app/Actions/LogMeal.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use App\Models\User;
+use App\Traits\PreventPastEntryEdits;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException;
+
+final readonly class LogMeal
+{
+    use PreventPastEntryEdits;
+
+    public function __construct(
+        private User $user,
+        private JournalEntry $entry,
+        private ?string $breakfast,
+        private ?string $lunch,
+        private ?string $dinner,
+        private ?string $snack,
+        private ?string $mealType,
+        private ?string $socialContext,
+        private ?string $notes,
+    ) {}
+
+    public function execute(): JournalEntry
+    {
+        $this->validate();
+        $this->log();
+        $this->logUserAction();
+        $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
+
+        $this->entry->load('moduleMeal');
+
+        return $this->entry;
+    }
+
+    private function validate(): void
+    {
+        if ($this->entry->journal->user_id !== $this->user->id) {
+            throw new ModelNotFoundException('Journal entry not found');
+        }
+
+        $this->preventPastEditsAllowed($this->entry);
+
+        if ($this->breakfast === null
+            && $this->lunch === null
+            && $this->dinner === null
+            && $this->snack === null
+            && $this->mealType === null
+            && $this->socialContext === null
+            && $this->notes === null
+        ) {
+            throw ValidationException::withMessages([
+                'meal' => 'At least one meal value is required.',
+            ]);
+        }
+
+        if ($this->breakfast !== null && ! in_array($this->breakfast, ModuleMeal::MEAL_PRESENCE, true)) {
+            throw ValidationException::withMessages([
+                'breakfast' => 'Invalid breakfast value.',
+            ]);
+        }
+
+        if ($this->lunch !== null && ! in_array($this->lunch, ModuleMeal::MEAL_PRESENCE, true)) {
+            throw ValidationException::withMessages([
+                'lunch' => 'Invalid lunch value.',
+            ]);
+        }
+
+        if ($this->dinner !== null && ! in_array($this->dinner, ModuleMeal::MEAL_PRESENCE, true)) {
+            throw ValidationException::withMessages([
+                'dinner' => 'Invalid dinner value.',
+            ]);
+        }
+
+        if ($this->snack !== null && ! in_array($this->snack, ModuleMeal::MEAL_PRESENCE, true)) {
+            throw ValidationException::withMessages([
+                'snack' => 'Invalid snack value.',
+            ]);
+        }
+
+        if ($this->mealType !== null && ! in_array($this->mealType, ModuleMeal::MEAL_TYPES, true)) {
+            throw ValidationException::withMessages([
+                'meal_type' => 'Invalid meal type value.',
+            ]);
+        }
+
+        if ($this->socialContext !== null && ! in_array($this->socialContext, ModuleMeal::SOCIAL_CONTEXTS, true)) {
+            throw ValidationException::withMessages([
+                'social_context' => 'Invalid social context value.',
+            ]);
+        }
+    }
+
+    private function log(): void
+    {
+        $moduleMeal = $this->entry->moduleMeal()->firstOrCreate(
+            ['journal_entry_id' => $this->entry->id],
+        );
+
+        if ($this->breakfast !== null) {
+            $moduleMeal->breakfast = $this->breakfast;
+        }
+
+        if ($this->lunch !== null) {
+            $moduleMeal->lunch = $this->lunch;
+        }
+
+        if ($this->dinner !== null) {
+            $moduleMeal->dinner = $this->dinner;
+        }
+
+        if ($this->snack !== null) {
+            $moduleMeal->snack = $this->snack;
+        }
+
+        if ($this->mealType !== null) {
+            $moduleMeal->meal_type = $this->mealType;
+        }
+
+        if ($this->socialContext !== null) {
+            $moduleMeal->social_context = $this->socialContext;
+        }
+
+        if ($this->notes !== null) {
+            $moduleMeal->notes = $this->notes;
+        }
+
+        $moduleMeal->save();
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            journal: $this->entry->journal,
+            action: 'meal_logged',
+            description: 'Logged meals for ' . $this->entry->getDate(),
+        )->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
+    }
+}

--- a/app/Actions/ResetMealData.php
+++ b/app/Actions/ResetMealData.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Jobs\CheckPresenceOfContentInJournalEntry;
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final readonly class ResetMealData
+{
+    public function __construct(
+        private User $user,
+        private JournalEntry $entry,
+    ) {}
+
+    public function execute(): JournalEntry
+    {
+        $this->validate();
+
+        $moduleMeal = $this->entry->moduleMeal;
+        if ($moduleMeal !== null) {
+            $moduleMeal->delete();
+        }
+
+        $this->logUserAction();
+        $this->updateUserLastActivityDate();
+        $this->refreshContentPresenceStatus();
+
+        $this->entry->load('moduleMeal');
+
+        return $this->entry;
+    }
+
+    private function validate(): void
+    {
+        if ($this->entry->journal->user_id !== $this->user->id) {
+            throw new ModelNotFoundException('Journal entry not found');
+        }
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            journal: $this->entry->journal,
+            action: 'meal_reset',
+            description: 'Reset meal data for ' . $this->entry->getDate(),
+        )->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function refreshContentPresenceStatus(): void
+    {
+        CheckPresenceOfContentInJournalEntry::dispatch($this->entry)->onQueue('low');
+    }
+}

--- a/app/Http/Controllers/Api/Journals/Modules/Meal/MealController.php
+++ b/app/Http/Controllers/Api/Journals/Modules/Meal/MealController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Journals\Modules\Meal;
+
+use App\Actions\LogMeal;
+use App\Helpers\TextSanitizer;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\JournalEntryResource;
+use App\Models\ModuleMeal;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+final class MealController extends Controller
+{
+    public function update(Request $request): JsonResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $validated = $request->validate([
+            'breakfast' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:lunch,dinner,snack,meal_type,social_context,notes'],
+            'lunch' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,dinner,snack,meal_type,social_context,notes'],
+            'dinner' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,lunch,snack,meal_type,social_context,notes'],
+            'snack' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,lunch,dinner,meal_type,social_context,notes'],
+            'meal_type' => ['nullable', 'string', 'max:255', Rule::in(ModuleMeal::MEAL_TYPES), 'required_without_all:breakfast,lunch,dinner,snack,social_context,notes'],
+            'social_context' => ['nullable', 'string', 'max:255', Rule::in(ModuleMeal::SOCIAL_CONTEXTS), 'required_without_all:breakfast,lunch,dinner,snack,meal_type,notes'],
+            'notes' => ['nullable', 'string', 'min:1', 'max:1000', 'required_without_all:breakfast,lunch,dinner,snack,meal_type,social_context'],
+        ]);
+
+        $entry = new LogMeal(
+            user: Auth::user(),
+            entry: $entry,
+            breakfast: array_key_exists('breakfast', $validated) ? TextSanitizer::nullablePlainText($validated['breakfast']) : null,
+            lunch: array_key_exists('lunch', $validated) ? TextSanitizer::nullablePlainText($validated['lunch']) : null,
+            dinner: array_key_exists('dinner', $validated) ? TextSanitizer::nullablePlainText($validated['dinner']) : null,
+            snack: array_key_exists('snack', $validated) ? TextSanitizer::nullablePlainText($validated['snack']) : null,
+            mealType: array_key_exists('meal_type', $validated) ? TextSanitizer::nullablePlainText($validated['meal_type']) : null,
+            socialContext: array_key_exists('social_context', $validated) ? TextSanitizer::nullablePlainText($validated['social_context']) : null,
+            notes: array_key_exists('notes', $validated) ? TextSanitizer::nullablePlainText($validated['notes']) : null,
+        )->execute();
+
+        return response()->json([
+            'data' => new JournalEntryResource($entry),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/App/Journals/Modules/Meal/MealController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Meal/MealController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\App\Journals\Modules\Meal;
+
+use App\Actions\LogMeal;
+use App\Helpers\TextSanitizer;
+use App\Http\Controllers\Controller;
+use App\Models\ModuleMeal;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+final class MealController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        $validated = $request->validate([
+            'breakfast' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:lunch,dinner,snack,meal_type,social_context,notes'],
+            'lunch' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,dinner,snack,meal_type,social_context,notes'],
+            'dinner' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,lunch,snack,meal_type,social_context,notes'],
+            'snack' => ['nullable', 'string', 'max:255', 'in:yes,no', 'required_without_all:breakfast,lunch,dinner,meal_type,social_context,notes'],
+            'meal_type' => ['nullable', 'string', 'max:255', Rule::in(ModuleMeal::MEAL_TYPES), 'required_without_all:breakfast,lunch,dinner,snack,social_context,notes'],
+            'social_context' => ['nullable', 'string', 'max:255', Rule::in(ModuleMeal::SOCIAL_CONTEXTS), 'required_without_all:breakfast,lunch,dinner,snack,meal_type,notes'],
+            'notes' => ['nullable', 'string', 'min:1', 'max:1000', 'required_without_all:breakfast,lunch,dinner,snack,meal_type,social_context'],
+        ]);
+
+        new LogMeal(
+            user: Auth::user(),
+            entry: $entry,
+            breakfast: array_key_exists('breakfast', $validated) ? TextSanitizer::plainText($validated['breakfast']) : null,
+            lunch: array_key_exists('lunch', $validated) ? TextSanitizer::plainText($validated['lunch']) : null,
+            dinner: array_key_exists('dinner', $validated) ? TextSanitizer::plainText($validated['dinner']) : null,
+            snack: array_key_exists('snack', $validated) ? TextSanitizer::plainText($validated['snack']) : null,
+            mealType: array_key_exists('meal_type', $validated) ? TextSanitizer::plainText($validated['meal_type']) : null,
+            socialContext: array_key_exists('social_context', $validated) ? TextSanitizer::plainText($validated['social_context']) : null,
+            notes: array_key_exists('notes', $validated) ? TextSanitizer::nullablePlainText($validated['notes']) : null,
+        )->execute();
+
+        return to_route('journal.entry.show', [
+            'slug' => $entry->journal->slug,
+            'year' => $entry->year,
+            'month' => $entry->month,
+            'day' => $entry->day,
+        ])->with('status', __('Changes saved'));
+    }
+}

--- a/app/Http/Controllers/App/Journals/Modules/Meal/MealResetController.php
+++ b/app/Http/Controllers/App/Journals/Modules/Meal/MealResetController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\App\Journals\Modules\Meal;
+
+use App\Actions\ResetMealData;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class MealResetController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $entry = $request->attributes->get('journal_entry');
+
+        new ResetMealData(
+            user: Auth::user(),
+            entry: $entry,
+        )->execute();
+
+        return to_route('journal.entry.show', [
+            'slug' => $entry->journal->slug,
+            'year' => $entry->year,
+            'month' => $entry->month,
+            'day' => $entry->day,
+        ])->with('status', __('Changes saved'));
+    }
+}

--- a/app/Http/Controllers/Marketing/Docs/Api/Modules/MealController.php
+++ b/app/Http/Controllers/Marketing/Docs/Api/Modules/MealController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\View\View;
+
+final class MealController extends Controller
+{
+    public function index(): View
+    {
+        RecordMarketingPageVisit::dispatch(viewName: 'marketing.docs.api.modules.meal')->onQueue('low');
+
+        return view('marketing.docs.api.modules.meal');
+    }
+}

--- a/app/Http/Resources/JournalEntryResource.php
+++ b/app/Http/Resources/JournalEntryResource.php
@@ -78,6 +78,15 @@ final class JournalEntryResource extends JsonResource
                         'brushed_teeth' => $this->moduleHygiene?->brushed_teeth,
                         'skincare' => $this->moduleHygiene?->skincare,
                     ],
+                    'meal' => [
+                        'breakfast' => $this->moduleMeal?->breakfast,
+                        'lunch' => $this->moduleMeal?->lunch,
+                        'dinner' => $this->moduleMeal?->dinner,
+                        'snack' => $this->moduleMeal?->snack,
+                        'meal_type' => $this->moduleMeal?->meal_type,
+                        'social_context' => $this->moduleMeal?->social_context,
+                        'notes' => $this->moduleMeal?->notes,
+                    ],
                     'mood' => [
                         'mood' => $this->moduleMood?->mood,
                     ],

--- a/app/Jobs/CheckPresenceOfContentInJournalEntry.php
+++ b/app/Jobs/CheckPresenceOfContentInJournalEntry.php
@@ -35,6 +35,7 @@ final class CheckPresenceOfContentInJournalEntry implements ShouldQueue
             'moduleSexualActivity',
             'moduleHealth',
             'moduleHygiene',
+            'moduleMeal',
             'moduleDayType',
             'moduleTravel',
             'moduleShopping',
@@ -109,6 +110,13 @@ final class CheckPresenceOfContentInJournalEntry implements ShouldQueue
         if (! $hasContent && $this->entry->moduleHygiene !== null) {
             $moduleHygiene = $this->entry->moduleHygiene;
             if ($moduleHygiene->showered !== null || $moduleHygiene->brushed_teeth !== null || $moduleHygiene->skincare !== null) {
+                $hasContent = true;
+            }
+        }
+
+        if (! $hasContent && $this->entry->moduleMeal !== null) {
+            $moduleMeal = $this->entry->moduleMeal;
+            if ($moduleMeal->breakfast !== null || $moduleMeal->lunch !== null || $moduleMeal->dinner !== null || $moduleMeal->snack !== null || $moduleMeal->meal_type !== null || $moduleMeal->social_context !== null || $moduleMeal->notes !== null) {
                 $hasContent = true;
             }
         }

--- a/app/Jobs/DeleteRelatedJournalData.php
+++ b/app/Jobs/DeleteRelatedJournalData.php
@@ -28,6 +28,7 @@ final class DeleteRelatedJournalData implements ShouldQueue
         'module_travel' => 'journal_entry_id',
         'module_health' => 'journal_entry_id',
         'module_hygiene' => 'journal_entry_id',
+        'module_meal' => 'journal_entry_id',
         'module_mood' => 'journal_entry_id',
         'module_day_type' => 'journal_entry_id',
         'module_physical_activity' => 'journal_entry_id',

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool $show_physical_activity_module
  * @property bool $show_health_module
  * @property bool $show_hygiene_module
+ * @property bool $show_meal_module
  * @property bool $show_mood_module
  * @property bool $show_sexual_activity_module
  * @property bool $show_energy_module
@@ -69,6 +70,7 @@ final class Journal extends Model
         'show_physical_activity_module',
         'show_health_module',
         'show_hygiene_module',
+        'show_meal_module',
         'show_mood_module',
         'show_sexual_activity_module',
         'show_energy_module',
@@ -96,6 +98,7 @@ final class Journal extends Model
             'show_physical_activity_module' => 'boolean',
             'show_health_module' => 'boolean',
             'show_hygiene_module' => 'boolean',
+            'show_meal_module' => 'boolean',
             'show_mood_module' => 'boolean',
             'show_sexual_activity_module' => 'boolean',
             'show_energy_module' => 'boolean',

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -225,6 +225,16 @@ final class JournalEntry extends Model
     }
 
     /**
+     * Get the meal module data for this entry.
+     *
+     * @return HasOne<ModuleMeal, $this>
+     */
+    public function moduleMeal(): HasOne
+    {
+        return $this->hasOne(ModuleMeal::class, 'journal_entry_id');
+    }
+
+    /**
      * Get the physical activity module data for this entry.
      *
      * @return HasOne<ModulePhysicalActivity, $this>

--- a/app/Models/ModuleMeal.php
+++ b/app/Models/ModuleMeal.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class ModuleMeal
+ *
+ * Represents meal tracking data for a journal entry.
+ *
+ * @property int $id
+ * @property int $journal_entry_id
+ * @property string $category # Format: string
+ * @property string|null $breakfast # Format: 'yes'|'no'
+ * @property string|null $lunch # Format: 'yes'|'no'
+ * @property string|null $dinner # Format: 'yes'|'no'
+ * @property string|null $snack # Format: 'yes'|'no'
+ * @property string|null $meal_type # Format: 'home_cooked'|'takeout'|'restaurant'|'work_cafeteria'
+ * @property string|null $social_context # Format: 'alone'|'family'|'friends'|'colleagues'
+ * @property string|null $notes # Format: string
+ * @property Carbon $created_at
+ * @property Carbon|null $updated_at
+ */
+final class ModuleMeal extends Model
+{
+    /** @use HasFactory<\Database\Factories\ModuleMealFactory> */
+    use HasFactory;
+
+    public const array MEAL_PRESENCE = [
+        'yes',
+        'no',
+    ];
+
+    public const array MEAL_TYPES = [
+        'home_cooked',
+        'takeout',
+        'restaurant',
+        'work_cafeteria',
+    ];
+
+    public const array SOCIAL_CONTEXTS = [
+        'alone',
+        'family',
+        'friends',
+        'colleagues',
+    ];
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'module_meal';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'journal_entry_id',
+        'category',
+        'breakfast',
+        'lunch',
+        'dinner',
+        'snack',
+        'meal_type',
+        'social_context',
+        'notes',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'breakfast' => 'encrypted',
+            'lunch' => 'encrypted',
+            'dinner' => 'encrypted',
+            'snack' => 'encrypted',
+            'meal_type' => 'encrypted',
+            'social_context' => 'encrypted',
+            'notes' => 'encrypted',
+        ];
+    }
+
+    /**
+     * Get the journal entry that owns the meal module.
+     *
+     * @return BelongsTo<JournalEntry, $this>
+     */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(JournalEntry::class, 'journal_entry_id');
+    }
+}

--- a/app/View/Presenters/JournalEntryPresenter.php
+++ b/app/View/Presenters/JournalEntryPresenter.php
@@ -72,6 +72,12 @@ final readonly class JournalEntryPresenter
             $hygiene = [];
         }
 
+        if ($this->entry->journal->show_meal_module) {
+            $meal = new MealModulePresenter($this->entry)->build();
+        } else {
+            $meal = [];
+        }
+
         if ($this->entry->journal->show_mood_module) {
             $mood = new MoodModulePresenter($this->entry)->build();
         } else {
@@ -109,6 +115,7 @@ final readonly class JournalEntryPresenter
             'physical_activity' => $physicalActivity,
             'health' => $health,
             'hygiene' => $hygiene,
+            'meal' => $meal,
             'mood' => $mood,
             'sexual_activity' => $sexualActivity,
             'energy' => $energy,

--- a/app/View/Presenters/MealModulePresenter.php
+++ b/app/View/Presenters/MealModulePresenter.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Presenters;
+
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+
+final readonly class MealModulePresenter
+{
+    public function __construct(
+        private JournalEntry $entry,
+    ) {}
+
+    public function build(): array
+    {
+        $moduleMeal = $this->entry->moduleMeal;
+
+        return [
+            'breakfast' => $moduleMeal?->breakfast,
+            'lunch' => $moduleMeal?->lunch,
+            'dinner' => $moduleMeal?->dinner,
+            'snack' => $moduleMeal?->snack,
+            'meal_type' => $moduleMeal?->meal_type,
+            'meal_type_options' => $this->mealTypeOptions(),
+            'social_context' => $moduleMeal?->social_context,
+            'social_context_options' => $this->socialContextOptions(),
+            'notes' => $moduleMeal?->notes,
+            'meal_url' => route('journal.entry.meal.update', [
+                'slug' => $this->entry->journal->slug,
+                'year' => $this->entry->year,
+                'month' => $this->entry->month,
+                'day' => $this->entry->day,
+            ]),
+            'reset_url' => route('journal.entry.meal.reset', [
+                'slug' => $this->entry->journal->slug,
+                'year' => $this->entry->year,
+                'month' => $this->entry->month,
+                'day' => $this->entry->day,
+            ]),
+            'display_reset' => $this->displayReset(),
+        ];
+    }
+
+    private function mealTypeOptions(): array
+    {
+        $mealType = $this->entry->moduleMeal?->meal_type;
+
+        return collect(ModuleMeal::MEAL_TYPES)->map(fn(string $value) => [
+            'value' => $value,
+            'label' => match ($value) {
+                'home_cooked' => __('Home-cooked'),
+                'takeout' => __('Takeout'),
+                'restaurant' => __('Restaurant'),
+                'work_cafeteria' => __('Work cafeteria'),
+                default => $value,
+            },
+            'is_selected' => $mealType === $value,
+        ])->all();
+    }
+
+    private function socialContextOptions(): array
+    {
+        $socialContext = $this->entry->moduleMeal?->social_context;
+
+        return collect(ModuleMeal::SOCIAL_CONTEXTS)->map(fn(string $value) => [
+            'value' => $value,
+            'label' => match ($value) {
+                'alone' => __('Alone'),
+                'family' => __('Family'),
+                'friends' => __('Friends'),
+                'colleagues' => __('Colleagues'),
+                default => $value,
+            },
+            'is_selected' => $socialContext === $value,
+        ])->all();
+    }
+
+    private function displayReset(): bool
+    {
+        $moduleMeal = $this->entry->moduleMeal;
+
+        if ($moduleMeal === null) {
+            return false;
+        }
+
+        return ! is_null($moduleMeal->breakfast)
+            || ! is_null($moduleMeal->lunch)
+            || ! is_null($moduleMeal->dinner)
+            || ! is_null($moduleMeal->snack)
+            || ! is_null($moduleMeal->meal_type)
+            || ! is_null($moduleMeal->social_context)
+            || ! is_null($moduleMeal->notes);
+    }
+}

--- a/database/factories/ModuleMealFactory.php
+++ b/database/factories/ModuleMealFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ModuleMeal>
+ */
+final class ModuleMealFactory extends Factory
+{
+    protected $model = ModuleMeal::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'journal_entry_id' => JournalEntry::factory(),
+            'breakfast' => $this->faker->randomElement(ModuleMeal::MEAL_PRESENCE),
+            'lunch' => $this->faker->randomElement(ModuleMeal::MEAL_PRESENCE),
+            'dinner' => $this->faker->randomElement(ModuleMeal::MEAL_PRESENCE),
+            'snack' => $this->faker->randomElement(ModuleMeal::MEAL_PRESENCE),
+            'meal_type' => $this->faker->randomElement(ModuleMeal::MEAL_TYPES),
+            'social_context' => $this->faker->randomElement(ModuleMeal::SOCIAL_CONTEXTS),
+            'notes' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2026_01_10_000000_create_module_meal_table.php
+++ b/database/migrations/2026_01_10_000000_create_module_meal_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ModuleType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('module_meal', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('journal_entry_id');
+            $table->string('category')->default(ModuleType::BODY_HEALTH->value);
+            $table->string('breakfast')->nullable();
+            $table->string('lunch')->nullable();
+            $table->string('dinner')->nullable();
+            $table->string('snack')->nullable();
+            $table->string('meal_type')->nullable();
+            $table->string('social_context')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->foreign('journal_entry_id')->references('id')->on('journal_entries')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('module_meal');
+    }
+};

--- a/database/migrations/2026_01_10_000001_add_show_meal_module_to_journals_table.php
+++ b/database/migrations/2026_01_10_000001_add_show_meal_module_to_journals_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('journals', function (Blueprint $table): void {
+            $table->boolean('show_meal_module')->default(true)->after('show_hygiene_module');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('journals', function (Blueprint $table): void {
+            $table->dropColumn('show_meal_module');
+        });
+    }
+};

--- a/database/seeders/ModuleMealSeeder.php
+++ b/database/seeders/ModuleMealSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\ModuleMeal;
+use Illuminate\Database\Seeder;
+
+final class ModuleMealSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        ModuleMeal::factory()->count(5)->create();
+    }
+}

--- a/docs/bruno/JournalOS/Journals/Modules/Meal/Log meal.bru
+++ b/docs/bruno/JournalOS/Journals/Modules/Meal/Log meal.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Log meal
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{URL}}/journals/1/2024/12/25/meal
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "breakfast": "yes",
+    "meal_type": "home_cooked",
+    "social_context": "family",
+    "notes": "Oatmeal and fruit."
+  }
+}

--- a/resources/views/app/journal/entry/partials/meal.blade.php
+++ b/resources/views/app/journal/entry/partials/meal.blade.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @var array<string, mixed> $module
+ */
+?>
+
+<x-module>
+  <x-slot:title>{{ __('Meals') }}</x-slot>
+  <x-slot:emoji>🍽️</x-slot>
+  <x-slot:action>
+    <div id="meal-reset">
+      @if ($module['display_reset'])
+        <x-form x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['reset_url']" method="put">
+          <button type="submit" class="inline cursor-pointer underline decoration-gray-300 underline-offset-4 transition-colors duration-200 hover:text-blue-600 hover:decoration-blue-400 hover:decoration-[1.15px] dark:decoration-gray-600 dark:hover:text-blue-400 dark:hover:decoration-blue-400">
+            {{ __('Reset') }}
+          </button>
+        </x-form>
+      @endif
+    </div>
+  </x-slot>
+
+  <div id="meal-container" class="space-y-4">
+    <div class="space-y-2">
+      <p>{{ __('Breakfast') }}</p>
+      <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <x-button.yes name="breakfast" value="yes" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['breakfast'] === 'yes' }}" />
+        <x-button.no name="breakfast" value="no" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['breakfast'] === 'no' }}" />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Lunch') }}</p>
+      <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <x-button.yes name="lunch" value="yes" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['lunch'] === 'yes' }}" />
+        <x-button.no name="lunch" value="no" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['lunch'] === 'no' }}" />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Dinner') }}</p>
+      <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <x-button.yes name="dinner" value="yes" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['dinner'] === 'yes' }}" />
+        <x-button.no name="dinner" value="no" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['dinner'] === 'no' }}" />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Snack') }}</p>
+      <div class="flex w-full rounded-lg border border-gray-200 dark:border-gray-700">
+        <x-button.yes name="snack" value="yes" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['snack'] === 'yes' }}" />
+        <x-button.no name="snack" value="no" x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" selected="{{ $module['snack'] === 'no' }}" />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Meal type') }}</p>
+      <div class="grid grid-cols-2 gap-2">
+        @foreach ($module['meal_type_options'] as $option)
+          <x-form x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" method="put">
+            <input type="hidden" name="meal_type" value="{{ $option['value'] }}" />
+            <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} w-full rounded-lg border border-gray-200 p-2 text-center hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">
+              {{ $option['label'] }}
+            </button>
+          </x-form>
+        @endforeach
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Social context') }}</p>
+      <div class="grid grid-cols-2 gap-2">
+        @foreach ($module['social_context_options'] as $option)
+          <x-form x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" method="put">
+            <input type="hidden" name="social_context" value="{{ $option['value'] }}" />
+            <button type="submit" class="{{ $option['is_selected'] ? 'bg-green-50 font-bold dark:bg-green-900/40' : '' }} w-full rounded-lg border border-gray-200 p-2 text-center hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">
+              {{ $option['label'] }}
+            </button>
+          </x-form>
+        @endforeach
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <p>{{ __('Notes') }}</p>
+      <x-form x-target="meal-container notifications meal-reset days-listing months-listing" :action="$module['meal_url']" method="put">
+        <div class="flex flex-col gap-2">
+          <textarea name="notes" rows="2" class="h-auto w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-xs placeholder:text-neutral-400 focus:border-indigo-500 focus:ring-1 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:border-indigo-600 dark:focus:ring-indigo-600" placeholder="{{ __('Anything to remember?') }}">{{ $module['notes'] }}</textarea>
+          <div class="flex justify-end">
+            <button type="submit" class="rounded-lg border border-gray-200 px-3 py-2 text-sm hover:bg-green-50 dark:border-gray-700 dark:hover:bg-green-900/40">
+              {{ __('Save notes') }}
+            </button>
+          </div>
+        </div>
+      </x-form>
+    </div>
+  </div>
+</x-module>

--- a/resources/views/app/journal/entry/show.blade.php
+++ b/resources/views/app/journal/entry/show.blade.php
@@ -133,6 +133,10 @@
           @include('app.journal.entry.partials.health', ['module' => $modules['health']])
         @endif
 
+        @if ($journal->show_meal_module)
+          @include('app.journal.entry.partials.meal', ['module' => $modules['meal']])
+        @endif
+
         @if ($journal->show_hygiene_module)
           @include('app.journal.entry.partials.hygiene', ['module' => $modules['hygiene']])
         @endif

--- a/resources/views/app/journal/settings/partials/modules.blade.php
+++ b/resources/views/app/journal/settings/partials/modules.blade.php
@@ -15,12 +15,12 @@
     <div class="inline-flex h-9 items-center justify-start gap-1 rounded-lg bg-gray-100 p-1 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
       <button type="button" @click="activeTab = 'all'" :class="activeTab === 'all' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>{{ __('All') }}</span>
-        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">14</span>
+        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">15</span>
       </button>
       <button type="button" @click="activeTab = 'body'" :class="activeTab === 'body' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>💪</span>
         <span>{{ __('Body & Health') }}</span>
-        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">4</span>
+        <span class="rounded-full bg-gray-200 px-2 py-0.5 text-xs dark:bg-gray-700">5</span>
       </button>
       <button type="button" @click="activeTab = 'mind'" :class="activeTab === 'mind' ? 'bg-white text-gray-900 shadow dark:bg-gray-950 dark:text-gray-50' : ''" class="inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all hover:bg-white hover:shadow focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-gray-950 hover:dark:bg-gray-950 hover:dark:text-gray-50 dark:focus-visible:ring-gray-300">
         <span>🧠</span>
@@ -80,6 +80,17 @@
           <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Health module') }}</p>
           <div class="w-full justify-self-start">
             <x-toggle name="enabled" :checked="$journal->show_health_module">{{ $journal->show_health_module ? __('Enabled') : __('Disabled') }}</x-toggle>
+          </div>
+        </div>
+      </x-form>
+
+      <!-- meal module -->
+      <x-form method="put" action="{{ route('journal.settings.modules.update', ['slug' => $journal->slug]) }}" x-target="modules-container notifications" x-target.back="modules-container" id="meal-module-form">
+        <input type="hidden" name="module" value="meal" />
+        <div class="grid grid-cols-3 items-center border-b border-gray-200 p-3 hover:bg-blue-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Meal module') }}</p>
+          <div class="w-full justify-self-start">
+            <x-toggle name="enabled" :checked="$journal->show_meal_module">{{ $journal->show_meal_module ? __('Enabled') : __('Disabled') }}</x-toggle>
           </div>
         </div>
       </x-form>
@@ -231,6 +242,17 @@
           <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Health module') }}</p>
           <div class="w-full justify-self-start">
             <x-toggle name="enabled" :checked="$journal->show_health_module">{{ $journal->show_health_module ? __('Enabled') : __('Disabled') }}</x-toggle>
+          </div>
+        </div>
+      </x-form>
+
+      <!-- meal module -->
+      <x-form method="put" action="{{ route('journal.settings.modules.update', ['slug' => $journal->slug]) }}" x-target="modules-container notifications" x-target.back="modules-container">
+        <input type="hidden" name="module" value="meal" />
+        <div class="grid grid-cols-3 items-center border-b border-gray-200 p-3 hover:bg-blue-50 dark:border-gray-700 dark:hover:bg-gray-800">
+          <p class="col-span-2 block text-sm font-medium text-gray-700 dark:text-gray-300">{{ __('Meal module') }}</p>
+          <div class="w-full justify-self-start">
+            <x-toggle name="enabled" :checked="$journal->show_meal_module">{{ $journal->show_meal_module ? __('Enabled') : __('Disabled') }}</x-toggle>
           </div>
         </div>
       </x-form>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -132,6 +132,9 @@
                 <a href="{{ route('marketing.docs.api.modules.hygiene') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.hygiene') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Hygiene</a>
               </div>
               <div>
+                <a href="{{ route('marketing.docs.api.modules.meal') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.meal') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Meal</a>
+              </div>
+              <div>
                 <a href="{{ route('marketing.docs.api.modules.energy') }}" wire:navigate class="{{ request()->routeIs('marketing.docs.api.modules.energy') ? 'border-l-blue-400' : 'border-l-transparent' }} block border-l-3 pl-3 hover:border-l-blue-400 hover:underline">Energy</a>
               </div>
               <div>

--- a/resources/views/marketing/docs/api/modules/meal.blade.php
+++ b/resources/views/marketing/docs/api/modules/meal.blade.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * No view data.
+ */
+?>
+
+<x-marketing-docs-layout :breadcrumbItems="[
+  ['label' => 'Home', 'route' => route('marketing.index')],
+  ['label' => 'Documentation', 'route' => route('marketing.docs.api.index')],
+  ['label' => 'Modules'],
+  ['label' => 'Meal'],
+]">
+  <div class="py-16">
+    <x-marketing.docs.h1 title="Meal module" />
+
+    <x-marketing.docs.table-of-content :items="[
+      [
+        'id' => 'log-meal',
+        'title' => 'Log meal',
+      ],
+    ]" />
+
+    <div class="mb-10 grid grid-cols-1 gap-6 border-b border-gray-200 pb-10 sm:grid-cols-2 dark:border-gray-700">
+      <div>
+        <p class="mb-2">The meal module endpoint lets you log meal details for a journal entry.</p>
+        <p class="mb-2">Send any meal fields you have. At least one field is required.</p>
+      </div>
+      <div>
+        <x-marketing.docs.code title="Endpoints">
+          <div class="flex flex-col gap-y-2">
+            <a href="#log-meal">
+              <span class="text-orange-500">PUT</span>
+              /api/journals/{id}/{year}/{month}/{day}/meal
+            </a>
+          </div>
+        </x-marketing.docs.code>
+      </div>
+    </div>
+
+    <!-- PUT /api/journals/{id}/{year}/{month}/{day}/meal -->
+    <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <x-marketing.docs.h2 id="log-meal" title="Log meal" />
+        <p class="mb-10">This endpoint logs meal details for a journal entry.</p>
+
+        <!-- url parameters -->
+        <x-marketing.docs.url-parameters>
+          <x-marketing.docs.attribute required name="id" type="integer" description="The ID of the journal." />
+          <x-marketing.docs.attribute required name="year" type="integer" description="The year of the journal entry." />
+          <x-marketing.docs.attribute required name="month" type="integer" description="The month of the journal entry." />
+          <x-marketing.docs.attribute required name="day" type="integer" description="The day of the journal entry." />
+        </x-marketing.docs.url-parameters>
+
+        <!-- query parameters -->
+        <x-marketing.docs.query-parameters>
+          <x-marketing.docs.attribute name="breakfast" type="string" description="Whether you had breakfast. Accepted values are: yes, no." />
+          <x-marketing.docs.attribute name="lunch" type="string" description="Whether you had lunch. Accepted values are: yes, no." />
+          <x-marketing.docs.attribute name="dinner" type="string" description="Whether you had dinner. Accepted values are: yes, no." />
+          <x-marketing.docs.attribute name="snack" type="string" description="Whether you had a snack. Accepted values are: yes, no." />
+          <x-marketing.docs.attribute name="meal_type" type="string" description="How meals were prepared. Accepted values are: home_cooked, takeout, restaurant, work_cafeteria." />
+          <x-marketing.docs.attribute name="social_context" type="string" description="Who you ate with. Accepted values are: alone, family, friends, colleagues." />
+          <x-marketing.docs.attribute name="notes" type="string" description="Optional notes about meals." />
+        </x-marketing.docs.query-parameters>
+
+        <!-- response attributes -->
+        @include('marketing.docs.api.partials.journal-entry-response-attributes')
+      </div>
+      <div>
+        <x-marketing.docs.code title="/api/journals/{id}/{year}/{month}/{day}/meal" verb="PUT" verbClass="text-yellow-700">
+          @include('marketing.docs.api.partials.journal-entry-response')
+        </x-marketing.docs.code>
+      </div>
+    </div>
+  </div>
+</x-marketing-docs-layout>

--- a/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response-attributes.blade.php
@@ -42,6 +42,14 @@
   <x-marketing.docs.attribute name="attributes.modules.hygiene.showered" type="string" description="Whether you showered." />
   <x-marketing.docs.attribute name="attributes.modules.hygiene.brushed_teeth" type="string" description="When you brushed your teeth." />
   <x-marketing.docs.attribute name="attributes.modules.hygiene.skincare" type="string" description="Whether you did skincare." />
+  <x-marketing.docs.attribute name="attributes.modules.meal" type="object" description="The meal module payload." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.breakfast" type="string" description="Whether you had breakfast." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.lunch" type="string" description="Whether you had lunch." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.dinner" type="string" description="Whether you had dinner." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.snack" type="string" description="Whether you had a snack." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.meal_type" type="string" description="How meals were prepared." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.social_context" type="string" description="Who you ate with." />
+  <x-marketing.docs.attribute name="attributes.modules.meal.notes" type="string" description="Additional notes about meals." />
   <x-marketing.docs.attribute name="attributes.modules.mood" type="object" description="The mood module payload." />
   <x-marketing.docs.attribute name="attributes.modules.mood.mood" type="string" description="The mood for that day." />
   <x-marketing.docs.attribute name="attributes.modules.energy" type="object" description="The energy module payload." />

--- a/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
+++ b/resources/views/marketing/docs/api/partials/journal-entry-response.blade.php
@@ -152,6 +152,42 @@
   <span class="text-lime-700">"no"</span>
 </div>
 <div class="pl-16">},</div>
+<div class="pl-16">"meal": {</div>
+<div class="pl-20">
+  "breakfast":
+  <span class="text-lime-700">"yes"</span>
+  ,
+</div>
+<div class="pl-20">
+  "lunch":
+  <span class="text-lime-700">"yes"</span>
+  ,
+</div>
+<div class="pl-20">
+  "dinner":
+  <span class="text-lime-700">"no"</span>
+  ,
+</div>
+<div class="pl-20">
+  "snack":
+  <span class="text-lime-700">"yes"</span>
+  ,
+</div>
+<div class="pl-20">
+  "meal_type":
+  <span class="text-lime-700">"home_cooked"</span>
+  ,
+</div>
+<div class="pl-20">
+  "social_context":
+  <span class="text-lime-700">"family"</span>
+  ,
+</div>
+<div class="pl-20">
+  "notes":
+  <span class="text-lime-700">"Family dinner at home."</span>
+</div>
+<div class="pl-16">},</div>
 <div class="pl-16">"mood": {</div>
 <div class="pl-20">
   "mood":

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\Journals\Modules\Energy\EnergyController as EnergyM
 use App\Http\Controllers\Api\Journals\Modules\Health\HealthController as HealthModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Hygiene\HygieneController as HygieneModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Kids\KidsController as KidsModuleController;
+use App\Http\Controllers\Api\Journals\Modules\Meal\MealController as MealModuleController;
 use App\Http\Controllers\Api\Journals\Modules\Mood\MoodController as MoodModuleController;
 use App\Http\Controllers\Api\Journals\Modules\PhysicalActivity\PhysicalActivityController;
 use App\Http\Controllers\Api\Journals\Modules\PrimaryObligation\PrimaryObligationController as PrimaryObligationModuleController;
@@ -89,6 +90,9 @@ Route::name('api.')->group(function (): void {
 
                         Route::put('health', [HealthModuleController::class, 'update'])
                             ->name('journal.entry.health.update');
+
+                        Route::put('meal', [MealModuleController::class, 'update'])
+                            ->name('journal.entry.meal.update');
 
                         Route::put('hygiene', [HygieneModuleController::class, 'update'])
                             ->name('journal.entry.hygiene.update');

--- a/routes/marketing.php
+++ b/routes/marketing.php
@@ -27,6 +27,7 @@ Route::middleware(['marketing'])->group(function (): void {
     Route::get('/docs/api/modules/health', [Docs\Api\Modules\HealthController::class, 'index'])->name('marketing.docs.api.modules.health');
     Route::get('/docs/api/modules/hygiene', [Docs\Api\Modules\HygieneController::class, 'index'])->name('marketing.docs.api.modules.hygiene');
     Route::get('/docs/api/modules/kids', [Docs\Api\Modules\KidsController::class, 'index'])->name('marketing.docs.api.modules.kids');
+    Route::get('/docs/api/modules/meal', [Docs\Api\Modules\MealController::class, 'index'])->name('marketing.docs.api.modules.meal');
     Route::get('/docs/api/modules/mood', [Docs\Api\Modules\MoodController::class, 'index'])->name('marketing.docs.api.modules.mood');
     Route::get('/docs/api/modules/shopping', [Docs\Api\Modules\ShoppingController::class, 'index'])->name('marketing.docs.api.modules.shopping');
     Route::get('/docs/api/modules/social-density', [Docs\Api\Modules\SocialDensityController::class, 'index'])->name('marketing.docs.api.modules.social-density');

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,10 @@ Route::middleware(['auth', 'verified', 'throttle:60,1', 'set.locale'])->group(fu
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/health', [Journals\Modules\Health\HealthController::class, 'update'])->name('journal.entry.health.update');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/health/reset', [Journals\Modules\Health\HealthResetController::class, 'update'])->name('journal.entry.health.reset');
 
+                // meal
+                Route::put('journals/{slug}/entries/{year}/{month}/{day}/meal', [Journals\Modules\Meal\MealController::class, 'update'])->name('journal.entry.meal.update');
+                Route::put('journals/{slug}/entries/{year}/{month}/{day}/meal/reset', [Journals\Modules\Meal\MealResetController::class, 'update'])->name('journal.entry.meal.reset');
+
                 // hygiene
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/hygiene', [Journals\Modules\Hygiene\HygieneController::class, 'update'])->name('journal.entry.hygiene.update');
                 Route::put('journals/{slug}/entries/{year}/{month}/{day}/hygiene/reset', [Journals\Modules\Hygiene\HygieneResetController::class, 'update'])->name('journal.entry.hygiene.reset');

--- a/tests/Feature/Controllers/Api/Journals/Modules/Meal/MealControllerTest.php
+++ b/tests/Feature/Controllers/Api/Journals/Modules/Meal/MealControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Api\Journals\Modules\Meal;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MealControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_meal_details(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->putJson("/api/journals/{$journal->id}/2022/1/1/meal", [
+            'breakfast' => 'yes',
+            'meal_type' => 'restaurant',
+            'social_context' => 'friends',
+            'notes' => 'Quick brunch.',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.attributes.modules.meal.breakfast', 'yes');
+        $response->assertJsonPath('data.attributes.modules.meal.meal_type', 'restaurant');
+        $response->assertJsonPath('data.attributes.modules.meal.social_context', 'friends');
+        $response->assertJsonPath('data.attributes.modules.meal.notes', 'Quick brunch.');
+
+        $entry->refresh();
+        $entry->load('moduleMeal');
+        $this->assertEquals('yes', $entry->moduleMeal->breakfast);
+    }
+
+    #[Test]
+    public function it_validates_meal_type_must_be_valid(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->putJson("/api/journals/{$journal->id}/2022/1/1/meal", [
+            'meal_type' => 'invalid',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['meal_type']);
+    }
+
+    #[Test]
+    public function it_validates_meal_requires_at_least_one_value(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->putJson("/api/journals/{$journal->id}/2022/1/1/meal", []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['breakfast']);
+    }
+
+    #[Test]
+    public function it_returns_401_for_unauthenticated_user(): void
+    {
+        $journal = Journal::factory()->create();
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->putJson("/api/journals/{$journal->id}/2022/1/1/meal", [
+            'breakfast' => 'yes',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $journal = Journal::factory()->create();
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->putJson("/api/journals/{$journal->id}/2022/1/1/meal", [
+            'breakfast' => 'yes',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/App/Journals/Modules/Meal/MealControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Meal/MealControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\App\Journals\Modules\Meal;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MealControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_updates_meal_details_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/meal",
+            [
+                'breakfast' => 'yes',
+                'lunch' => 'no',
+                'meal_type' => 'home_cooked',
+                'social_context' => 'family',
+                'notes' => 'Simple lunch.',
+            ],
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2024/6/15");
+        $response->assertSessionHas('status');
+
+        $entry->refresh();
+        $this->assertEquals('yes', $entry->moduleMeal->breakfast);
+        $this->assertEquals('no', $entry->moduleMeal->lunch);
+        $this->assertEquals('home_cooked', $entry->moduleMeal->meal_type);
+        $this->assertEquals('family', $entry->moduleMeal->social_context);
+        $this->assertEquals('Simple lunch.', $entry->moduleMeal->notes);
+    }
+
+    #[Test]
+    public function it_validates_meal_type_must_be_valid(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/meal",
+            ['meal_type' => 'invalid'],
+        );
+
+        $response->assertSessionHasErrors('meal_type');
+    }
+
+    #[Test]
+    public function it_validates_meal_requires_at_least_one_value(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/meal",
+            [],
+        );
+
+        $response->assertSessionHasErrors('breakfast');
+    }
+
+    #[Test]
+    public function it_redirects_guests_to_login(): void
+    {
+        $journal = Journal::factory()->create();
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->put("/journals/{$journal->slug}/entries/2024/6/15/meal", [
+            'breakfast' => 'yes',
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 6,
+            'day' => 15,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2024/6/15/meal",
+            ['breakfast' => 'yes'],
+        );
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/Controllers/App/Journals/Modules/Meal/MealResetControllerTest.php
+++ b/tests/Feature/Controllers/App/Journals/Modules/Meal/MealResetControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\App\Journals\Modules\Meal;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MealResetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_meal_data_and_redirects(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'breakfast' => 'yes',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2022/1/1/meal/reset",
+        );
+
+        $response->assertRedirectContains("/journals/{$journal->slug}/entries/2022/1/1");
+        $response->assertSessionHas('status');
+
+        $entry->refresh();
+        $this->assertNull($entry->moduleMeal);
+    }
+
+    #[Test]
+    public function it_redirects_guests_to_login(): void
+    {
+        $journal = Journal::factory()->create();
+        JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+
+        $response = $this->put("/journals/{$journal->slug}/entries/2022/1/1/meal/reset");
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_returns_404_for_unauthorized_entry(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2022,
+            'month' => 1,
+            'day' => 1,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'breakfast' => 'no',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            "/journals/{$journal->slug}/entries/2022/1/1/meal/reset",
+        );
+
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/Controllers/Marketing/Docs/Api/Modules/MealControllerTest.php
+++ b/tests/Feature/Controllers/Marketing/Docs/Api/Modules/MealControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Controllers\Marketing\Docs\Api\Modules;
+
+use App\Jobs\RecordMarketingPageVisit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MealControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_renders_the_meal_module_api_docs_page(): void
+    {
+        Queue::fake();
+
+        $response = $this->get(route('marketing.docs.api.modules.meal', absolute: false));
+
+        $response->assertOk();
+        $response->assertViewIs('marketing.docs.api.modules.meal');
+
+        Queue::assertPushedOn('low', RecordMarketingPageVisit::class, function (RecordMarketingPageVisit $job): bool {
+            return $job->viewName === 'marketing.docs.api.modules.meal';
+        });
+    }
+}

--- a/tests/Unit/Actions/LogMealTest.php
+++ b/tests/Unit/Actions/LogMealTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\LogMeal;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class LogMealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_logs_meal_details(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $entry = new LogMeal(
+            user: $user,
+            entry: $entry,
+            breakfast: 'yes',
+            lunch: 'no',
+            dinner: 'yes',
+            snack: 'no',
+            mealType: 'home_cooked',
+            socialContext: 'family',
+            notes: 'Dinner with family.',
+        )->execute();
+
+        $this->assertEquals('yes', $entry->moduleMeal->breakfast);
+        $this->assertEquals('no', $entry->moduleMeal->lunch);
+        $this->assertEquals('yes', $entry->moduleMeal->dinner);
+        $this->assertEquals('no', $entry->moduleMeal->snack);
+        $this->assertEquals('home_cooked', $entry->moduleMeal->meal_type);
+        $this->assertEquals('family', $entry->moduleMeal->social_context);
+        $this->assertEquals('Dinner with family.', $entry->moduleMeal->notes);
+    }
+
+    #[Test]
+    public function it_requires_at_least_one_value(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new LogMeal(
+            user: $user,
+            entry: $entry,
+            breakfast: null,
+            lunch: null,
+            dinner: null,
+            snack: null,
+            mealType: null,
+            socialContext: null,
+            notes: null,
+        )->execute();
+    }
+
+    #[Test]
+    public function it_rejects_invalid_meal_type(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new LogMeal(
+            user: $user,
+            entry: $entry,
+            breakfast: 'yes',
+            lunch: null,
+            dinner: null,
+            snack: null,
+            mealType: 'invalid',
+            socialContext: null,
+            notes: null,
+        )->execute();
+    }
+
+    #[Test]
+    public function it_requires_the_entry_to_belong_to_the_user(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $this->expectException(ModelNotFoundException::class);
+
+        new LogMeal(
+            user: $user,
+            entry: $entry,
+            breakfast: 'yes',
+            lunch: null,
+            dinner: null,
+            snack: null,
+            mealType: null,
+            socialContext: null,
+            notes: null,
+        )->execute();
+    }
+}

--- a/tests/Unit/Actions/ResetMealDataTest.php
+++ b/tests/Unit/Actions/ResetMealDataTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\ResetMealData;
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ResetMealDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_resets_meal_data(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'breakfast' => 'yes',
+        ]);
+
+        $result = (new ResetMealData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+
+        $this->assertNull($result->moduleMeal);
+    }
+
+    #[Test]
+    public function it_requires_the_entry_to_belong_to_the_user(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+
+        $this->expectException(ModelNotFoundException::class);
+
+        (new ResetMealData(
+            user: $user,
+            entry: $entry,
+        ))->execute();
+    }
+}

--- a/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
+++ b/tests/Unit/Jobs/CheckPresenceOfContentInJournalEntryTest.php
@@ -9,6 +9,7 @@ use App\Models\Journal;
 use App\Models\JournalEntry;
 use App\Models\ModuleKids;
 use App\Models\ModuleHygiene;
+use App\Models\ModuleMeal;
 use App\Models\ModulePhysicalActivity;
 use App\Models\ModulePrimaryObligation;
 use App\Models\ModuleShopping;
@@ -200,6 +201,27 @@ final class CheckPresenceOfContentInJournalEntryTest extends TestCase
         ModuleShopping::factory()->create([
             'journal_entry_id' => $entry->id,
             'shopping_for' => 'for_self',
+        ]);
+
+        $job = new CheckPresenceOfContentInJournalEntry($entry);
+        $job->handle();
+
+        $entry->refresh();
+        $this->assertTrue($entry->has_content);
+    }
+
+    #[Test]
+    public function it_sets_has_content_to_true_when_meal_module_has_data(): void
+    {
+        $user = User::factory()->create();
+        $journal = Journal::factory()->create(['user_id' => $user->id]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'has_content' => false,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'breakfast' => 'yes',
         ]);
 
         $job = new CheckPresenceOfContentInJournalEntry($entry);

--- a/tests/Unit/Models/JournalEntryTest.php
+++ b/tests/Unit/Models/JournalEntryTest.php
@@ -13,6 +13,7 @@ use App\Models\ModuleHygiene;
 use App\Models\ModuleDayType;
 use App\Models\ModuleEnergy;
 use App\Models\ModulePhysicalActivity;
+use App\Models\ModuleMeal;
 use App\Models\ModuleShopping;
 use App\Models\ModuleSexualActivity;
 use App\Models\ModuleSleep;
@@ -213,6 +214,25 @@ final class JournalEntryTest extends TestCase
         $this->assertEquals($moduleShopping->id, $entry->moduleShopping->id);
         $this->assertEquals('yes', $entry->moduleShopping->has_shopped_today);
         $this->assertEquals(['groceries'], $entry->moduleShopping->shopping_type);
+    }
+
+    #[Test]
+    public function it_has_one_module_meal(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        $moduleMeal = ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'breakfast' => 'yes',
+            'meal_type' => 'home_cooked',
+        ]);
+
+        $this->assertTrue($entry->moduleMeal()->exists());
+        $this->assertEquals($moduleMeal->id, $entry->moduleMeal->id);
+        $this->assertEquals('yes', $entry->moduleMeal->breakfast);
+        $this->assertEquals('home_cooked', $entry->moduleMeal->meal_type);
     }
 
     #[Test]

--- a/tests/Unit/Models/ModuleMealTest.php
+++ b/tests/Unit/Models/ModuleMealTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ModuleMealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_belongs_to_a_journal_entry(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        $moduleMeal = ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+        ]);
+
+        $this->assertTrue($moduleMeal->entry()->exists());
+        $this->assertEquals($entry->id, $moduleMeal->entry->id);
+    }
+}

--- a/tests/Unit/Presenters/JournalEntryPresenterTest.php
+++ b/tests/Unit/Presenters/JournalEntryPresenterTest.php
@@ -35,6 +35,7 @@ final class JournalEntryPresenterTest extends TestCase
         $this->assertArrayHasKey('travel', $result);
         $this->assertArrayHasKey('day_type', $result);
         $this->assertArrayHasKey('hygiene', $result);
+        $this->assertArrayHasKey('meal', $result);
         $this->assertArrayHasKey('sexual_activity', $result);
         $this->assertArrayHasKey('energy', $result);
     }

--- a/tests/Unit/Presenters/MealModulePresenterTest.php
+++ b/tests/Unit/Presenters/MealModulePresenterTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Presenters;
+
+use App\Models\Journal;
+use App\Models\JournalEntry;
+use App\Models\ModuleMeal;
+use App\View\Presenters\MealModulePresenter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MealModulePresenterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_builds_meal_module_data(): void
+    {
+        $journal = Journal::factory()->create([
+            'slug' => 'my-journal',
+        ]);
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+            'year' => 2024,
+            'month' => 12,
+            'day' => 25,
+        ]);
+
+        $presenter = new MealModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('breakfast', $result);
+        $this->assertArrayHasKey('lunch', $result);
+        $this->assertArrayHasKey('dinner', $result);
+        $this->assertArrayHasKey('snack', $result);
+        $this->assertArrayHasKey('meal_type', $result);
+        $this->assertArrayHasKey('meal_type_options', $result);
+        $this->assertArrayHasKey('social_context', $result);
+        $this->assertArrayHasKey('social_context_options', $result);
+        $this->assertArrayHasKey('notes', $result);
+        $this->assertArrayHasKey('meal_url', $result);
+        $this->assertArrayHasKey('reset_url', $result);
+        $this->assertArrayHasKey('display_reset', $result);
+
+        $this->assertEquals(
+            route('journal.entry.meal.update', [
+                'slug' => $entry->journal->slug,
+                'year' => $entry->year,
+                'month' => $entry->month,
+                'day' => $entry->day,
+            ]),
+            $result['meal_url'],
+        );
+
+        $this->assertEquals(
+            route('journal.entry.meal.reset', [
+                'slug' => $entry->journal->slug,
+                'year' => $entry->year,
+                'month' => $entry->month,
+                'day' => $entry->day,
+            ]),
+            $result['reset_url'],
+        );
+
+        $this->assertCount(4, $result['meal_type_options']);
+        $this->assertCount(4, $result['social_context_options']);
+        $this->assertFalse($result['display_reset']);
+    }
+
+    #[Test]
+    public function it_marks_selected_meal_type_and_social_context(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'meal_type' => 'restaurant',
+            'social_context' => 'friends',
+        ]);
+
+        $presenter = new MealModulePresenter($entry);
+        $result = $presenter->build();
+
+        $selectedMealType = collect($result['meal_type_options'])->firstWhere('is_selected', true);
+        $selectedSocialContext = collect($result['social_context_options'])->firstWhere('is_selected', true);
+
+        $this->assertEquals('restaurant', $selectedMealType['value']);
+        $this->assertEquals('friends', $selectedSocialContext['value']);
+    }
+
+    #[Test]
+    public function it_displays_reset_when_meal_data_is_set(): void
+    {
+        $journal = Journal::factory()->create();
+        $entry = JournalEntry::factory()->create([
+            'journal_id' => $journal->id,
+        ]);
+        ModuleMeal::factory()->create([
+            'journal_entry_id' => $entry->id,
+            'notes' => 'Dinner with friends.',
+        ]);
+
+        $presenter = new MealModulePresenter($entry);
+        $result = $presenter->build();
+
+        $this->assertTrue($result['display_reset']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Hi — Add a meal tracking module to record breakfast/lunch/dinner/snack presence, meal type, social context and optional notes for journal entries.
- Provide both web and API support so users can log meals from the app or programmatically.
- Integrate presence detection so meals contribute to `has_content` for entries.
- Supply marketing docs and Bruno sample to document the new API.

### Description
- Add database migration, model, factory and seeder for `module_meal` with fields `breakfast`, `lunch`, `dinner`, `snack`, `meal_type`, `social_context`, and `notes` (`database/migrations/*`, `app/Models/ModuleMeal.php`, `database/factories/ModuleMealFactory.php`, `database/seeders/ModuleMealSeeder.php`).
- Implement actions `LogMeal` and `ResetMealData`, web and API controllers for updates and resets, presenter, view partial, and routes to wire UI and API (`app/Actions/LogMeal.php`, `app/Actions/ResetMealData.php`, `app/Http/Controllers/**/MealController.php`, `resources/views/app/journal/entry/partials/meal.blade.php`, routes updates).
- Wire module into presenters/resources/jobs/settings/docs: added `MealModulePresenter`, integrated into `JournalEntryPresenter`, included in `JournalEntryResource`, updated `CheckPresenceOfContentInJournalEntry`, `DeleteRelatedJournalData`, settings toggle and marketing docs + Bruno samples.
- Add comprehensive tests (unit and feature) for model, presenter, actions, web/API controllers and marketing docs (`tests/Unit/**`, `tests/Feature/**`).

### Testing
- Attempted to run `vendor/bin/pint --dirty` but formatting run failed because `vendor/` is missing (composer install could not complete). (failed)
- Attempted to run a single feature test via `php artisan test tests/Feature/Controllers/App/Journals/Modules/Meal/MealControllerTest.php` but it failed due to missing `vendor/autoload.php` after composer install failed. (failed)
- Attempted `composer journalos:locale` and `composer journalos:unit` but both could not run for the same `vendor` / composer install issue (GitHub downloads returned 403 during install). (failed)
- All new unit and feature tests were added to the repo and are ready to run once dependencies are installed. (not executed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965349e3ee88320a982385b0c0de72a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes: Meal Tracking Module

## Features
- **New Meal Tracking Module**: Record breakfast, lunch, dinner, and snack presence for journal entries
- **Meal Metadata**: Track meal type (home-cooked, takeout, restaurant, work cafeteria), social context (alone, family, friends, colleagues), and optional notes
- **Web Interface**: Intuitive form with Yes/No buttons for each meal, dropdowns for meal type and social context, and notes textarea
- **API Support**: New PUT endpoint `/journals/{id}/{year}/{month}/{day}/meal` for programmatic meal logging
- **Module Toggle**: Settings option to enable/disable the meal tracking module per journal
- **Content Integration**: Meal data now counts toward entry `has_content` flag for better entry completeness tracking
- **Reset Functionality**: Option to clear all meal data for an entry

## Technical
- Encrypted storage of all meal-related data in database
- Full relationship mapping between JournalEntry and ModuleMeal models
- Presence detection system integration for meals
- Comprehensive validation of meal inputs
- Background job handling for user activity logging and content presence updates

## Documentation
- Marketing API documentation page with endpoint specification
- Bruno API sample collection for testing meal endpoints
- API response attributes documentation updated with meal module fields

## Testing
- Unit tests for LogMeal and ResetMealData actions
- Feature tests for web and API controllers
- Model and presenter tests for meal tracking functionality
- Content presence detection tests
- 400+ lines of new test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->